### PR TITLE
n-heptane data

### DIFF
--- a/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: Kyle Niemeyer
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
     authors:
         - name: A. Burcat

--- a/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
@@ -1,25 +1,24 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
-    authors:
-        - name: A. Burcat
-        - name: R. F. Farmer
-        - name: A. Matula
-    journal: Proc 13th Int Symp Shock Tubes Waves
-    year: 1981
-    pages: 826-833
-    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+  authors:
+    - name: A. Burcat
+    - name: R. F. Farmer
+    - name: A. Matula
+  journal: Proc 13th Int Symp Shock Tubes Waves
+  year: 1981
+  pages: 826-833
+  detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
 experiment-type: ignition delay
 apparatus:
   facility: ''
-  institution: Oregon State University
+  institution: RWTH Aachen University
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +47,7 @@ datapoints:
   - 4.6600e+00 atm
   temperature:
   - 1.2600e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 7.0000e+01 us
@@ -56,6 +56,7 @@ datapoints:
   - 5.1700e+00 atm
   temperature:
   - 1.4100e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 1.7000e+02 us
@@ -64,6 +65,7 @@ datapoints:
   - 4.5200e+00 atm
   temperature:
   - 1.3230e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 6.4700e+02 us
@@ -72,6 +74,7 @@ datapoints:
   - 2.0300e+00 atm
   temperature:
   - 1.2680e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 1.5500e+02 us
@@ -80,6 +83,7 @@ datapoints:
   - 3.1500e+00 atm
   temperature:
   - 1.3410e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 2.5000e+01 us
@@ -88,6 +92,7 @@ datapoints:
   - 3.0800e+00 atm
   temperature:
   - 1.6020e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 8.7000e+01 us
@@ -96,6 +101,7 @@ datapoints:
   - 9.2300e+00 atm
   temperature:
   - 1.3610e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 2.0000e+02 us
@@ -104,6 +110,7 @@ datapoints:
   - 8.3400e+00 atm
   temperature:
   - 1.2860e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 1.0000e+00 us
@@ -112,3 +119,4 @@ datapoints:
   - 1.1810e+01 atm
   temperature:
   - 1.5650e+03 K
+  equivalence-ratio: 1

--- a/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
@@ -1,0 +1,111 @@
+file-author:
+    name: Kyle Niemeyer
+file-version: 0
+chemked-version: 0.3.0
+reference:
+    authors:
+        - name: A. Burcat
+        - name: R. F. Farmer
+        - name: A. Matula
+    journal: Proc 13th Int Symp Shock Tubes Waves
+    year: 1981
+    pages: 826-833
+    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: Oregon State University
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.11
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.88
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 3.2300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.6600e+00 atm
+  temperature:
+  - 1.2600e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.0000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 5.1700e+00 atm
+  temperature:
+  - 1.4100e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.5200e+00 atm
+  temperature:
+  - 1.3230e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.4700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0300e+00 atm
+  temperature:
+  - 1.2680e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.5500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.1500e+00 atm
+  temperature:
+  - 1.3410e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 3.0800e+00 atm
+  temperature:
+  - 1.6020e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.7000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 9.2300e+00 atm
+  temperature:
+  - 1.3610e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 8.3400e+00 atm
+  temperature:
+  - 1.2860e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.0000e+00 us
+  ignition-type: *id002
+  pressure:
+  - 1.1810e+01 atm
+  temperature:
+  - 1.5650e+03 K

--- a/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: Kyle Niemeyer
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: Kyle Niemeyer
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
     authors:
         - name: A. Burcat

--- a/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
@@ -1,0 +1,63 @@
+file-author:
+    name: Kyle Niemeyer
+file-version: 0
+chemked-version: 0.3.0
+reference:
+    authors:
+        - name: A. Burcat
+        - name: R. F. Farmer
+        - name: A. Matula
+    journal: Proc 13th Int Symp Shock Tubes Waves
+    year: 1981
+    pages: 826-833
+    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: Oregon State University
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.005
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.11
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.885
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 2.0000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.8100e+00 atm
+  temperature:
+  - 1.3110e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.3000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.5100e+00 atm
+  temperature:
+  - 1.2450e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.8100e+00 atm
+  temperature:
+  - 1.5030e+03 K

--- a/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: Kyle Niemeyer
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-2.yaml
@@ -1,25 +1,24 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
-    authors:
-        - name: A. Burcat
-        - name: R. F. Farmer
-        - name: A. Matula
-    journal: Proc 13th Int Symp Shock Tubes Waves
-    year: 1981
-    pages: 826-833
-    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+  authors:
+    - name: A. Burcat
+    - name: R. F. Farmer
+    - name: A. Matula
+  journal: Proc 13th Int Symp Shock Tubes Waves
+  year: 1981
+  pages: 826-833
+  detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
 experiment-type: ignition delay
 apparatus:
   facility: ''
-  institution: Oregon State University
+  institution: RWTH Aachen University
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +47,7 @@ datapoints:
   - 3.8100e+00 atm
   temperature:
   - 1.3110e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.3000e+02 us
@@ -56,6 +56,7 @@ datapoints:
   - 3.5100e+00 atm
   temperature:
   - 1.2450e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.7000e+01 us
@@ -64,3 +65,4 @@ datapoints:
   - 4.8100e+00 atm
   temperature:
   - 1.5030e+03 K
+  equivalence-ratio: 0.5

--- a/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
@@ -1,25 +1,24 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
-    authors:
-        - name: A. Burcat
-        - name: R. F. Farmer
-        - name: A. Matula
-    journal: Proc 13th Int Symp Shock Tubes Waves
-    year: 1981
-    pages: 826-833
-    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+  authors:
+    - name: A. Burcat
+    - name: R. F. Farmer
+    - name: A. Matula
+  journal: Proc 13th Int Symp Shock Tubes Waves
+  year: 1981
+  pages: 826-833
+  detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
 experiment-type: ignition delay
 apparatus:
   facility: ''
-  institution: Oregon State University
+  institution: RWTH Aachen University
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +47,7 @@ datapoints:
   - 5.0100e+00 atm
   temperature:
   - 1.2570e+03 K
+  equivalence-ratio: 2
 - composition: *id001
   ignition-delay:
   - 1.4000e+01 us
@@ -56,6 +56,7 @@ datapoints:
   - 7.9500e+00 atm
   temperature:
   - 1.5950e+03 K
+  equivalence-ratio: 2
 - composition: *id001
   ignition-delay:
   - 9.5000e+01 us
@@ -64,3 +65,4 @@ datapoints:
   - 6.1700e+00 atm
   temperature:
   - 1.4010e+03 K
+  equivalence-ratio: 2

--- a/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: Kyle Niemeyer
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
     authors:
         - name: A. Burcat

--- a/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
@@ -1,0 +1,63 @@
+file-author:
+    name: Kyle Niemeyer
+file-version: 0
+chemked-version: 0.3.0
+reference:
+    authors:
+        - name: A. Burcat
+        - name: R. F. Farmer
+        - name: A. Matula
+    journal: Proc 13th Int Symp Shock Tubes Waves
+    year: 1981
+    pages: 826-833
+    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: Oregon State University
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.02
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.11
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.87
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.5200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0100e+00 atm
+  temperature:
+  - 1.2570e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 7.9500e+00 atm
+  temperature:
+  - 1.5950e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 6.1700e+00 atm
+  temperature:
+  - 1.4010e+03 K

--- a/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-3.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: Kyle Niemeyer
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: Kyle Niemeyer
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
     authors:
         - name: A. Burcat

--- a/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
@@ -1,25 +1,24 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
-    authors:
-        - name: A. Burcat
-        - name: R. F. Farmer
-        - name: A. Matula
-    journal: Proc 13th Int Symp Shock Tubes Waves
-    year: 1981
-    pages: 826-833
-    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+  authors:
+     - name: A. Burcat
+     - name: R. F. Farmer
+     - name: A. Matula
+  journal: Proc 13th Int Symp Shock Tubes Waves
+  year: 1981
+  pages: 826-833
+  detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
 experiment-type: ignition delay
 apparatus:
   facility: ''
-  institution: Oregon State University
+  institution: RWTH Aachen University
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +47,7 @@ datapoints:
   - 5.1700e+00 atm
   temperature:
   - 1.6610e+03 K
+  equivalence-ratio: 2
 - composition: *id001
   ignition-delay:
   - 3.0300e+02 us
@@ -56,6 +56,7 @@ datapoints:
   - 4.0700e+00 atm
   temperature:
   - 1.4430e+03 K
+  equivalence-ratio: 2
 - composition: *id001
   ignition-delay:
   - 1.9000e+02 us
@@ -64,3 +65,4 @@ datapoints:
   - 4.4300e+00 atm
   temperature:
   - 1.5090e+03 K
+  equivalence-ratio: 2

--- a/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
@@ -1,0 +1,63 @@
+file-author:
+    name: Kyle Niemeyer
+file-version: 0
+chemked-version: 0.3.0
+reference:
+    authors:
+        - name: A. Burcat
+        - name: R. F. Farmer
+        - name: A. Matula
+    journal: Proc 13th Int Symp Shock Tubes Waves
+    year: 1981
+    pages: 826-833
+    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: Oregon State University
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.005
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.028
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.967
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 5.1700e+00 atm
+  temperature:
+  - 1.6610e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.0300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.0700e+00 atm
+  temperature:
+  - 1.4430e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.9000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.4300e+00 atm
+  temperature:
+  - 1.5090e+03 K

--- a/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-4.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: Kyle Niemeyer
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: Kyle Niemeyer
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
     authors:
         - name: A. Burcat

--- a/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
@@ -1,0 +1,63 @@
+file-author:
+    name: Kyle Niemeyer
+file-version: 0
+chemked-version: 0.3.0
+reference:
+    authors:
+        - name: A. Burcat
+        - name: R. F. Farmer
+        - name: A. Matula
+    journal: Proc 13th Int Symp Shock Tubes Waves
+    year: 1981
+    pages: 826-833
+    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.03
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.331
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.639
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 3.9000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.4200e+00 atm
+  temperature:
+  - 1.3420e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.9000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.2500e+00 atm
+  temperature:
+  - 1.1370e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.7000e+00 atm
+  temperature:
+  - 1.2540e+03 K

--- a/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
@@ -1,25 +1,24 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
-    authors:
-        - name: A. Burcat
-        - name: R. F. Farmer
-        - name: A. Matula
-    journal: Proc 13th Int Symp Shock Tubes Waves
-    year: 1981
-    pages: 826-833
-    detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
+  authors:
+    - name: A. Burcat
+    - name: R. F. Farmer
+    - name: A. Matula
+  journal: Proc 13th Int Symp Shock Tubes Waves
+  year: 1981
+  pages: 826-833
+  detail: Shock initiated ignition in heptane-oxygen-argon mixtures 
 experiment-type: ignition delay
 apparatus:
   facility: ''
-  institution: ''
+  institution: RWTH Aachen University
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +47,7 @@ datapoints:
   - 4.4200e+00 atm
   temperature:
   - 1.3420e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 4.9000e+02 us
@@ -56,6 +56,7 @@ datapoints:
   - 3.2500e+00 atm
   temperature:
   - 1.1370e+03 K
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
   - 1.4200e+02 us
@@ -64,3 +65,4 @@ datapoints:
   - 3.7000e+00 atm
   temperature:
   - 1.2540e+03 K
+  equivalence-ratio: 1

--- a/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
+++ b/n-heptane/Burcat 1981/st_burcat_1981-5.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: Kyle Niemeyer
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-1.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-1.yaml
@@ -1,0 +1,105 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.009458
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2081
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.782442
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 336 us
+  ignition-type: *id002
+  temperature:
+  - 1186.5 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 1574 us
+  ignition-type: *id002
+  temperature:
+  - 1055.3 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 3422 us
+  ignition-type: *id002
+  temperature:
+  - 997.94 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 5546 us
+  ignition-type: *id002
+  temperature:
+  - 788 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 5276 us
+  ignition-type: *id002
+  temperature:
+  - 771.83 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 5690 us
+  ignition-type: *id002
+  temperature:
+  - 748.15 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 8335 us
+  ignition-type: *id002
+  temperature:
+  - 696.24 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 0.5

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-2.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-2.yaml
@@ -1,0 +1,96 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 108 us
+  ignition-type: *id002
+  temperature:
+  - 1354.3 kelvin
+  pressure:
+  - 3.2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 171 us
+  ignition-type: *id002
+  temperature:
+  - 1324.6 kelvin
+  pressure:
+  - 3.2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 364 us
+  ignition-type: *id002
+  temperature:
+  - 1259.3 kelvin
+  pressure:
+  - 3.2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 485 us
+  ignition-type: *id002
+  temperature:
+  - 1245 kelvin
+  pressure:
+  - 3.2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1178 us
+  ignition-type: *id002
+  temperature:
+  - 1177.5 kelvin
+  pressure:
+  - 3.2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1749 us
+  ignition-type: *id002
+  temperature:
+  - 1131.6 kelvin
+  pressure:
+  - 3.2 bar
+  equivalence-ratio: 1

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-3.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-3.yaml
@@ -1,0 +1,114 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 109 us
+  ignition-type: *id002
+  temperature:
+  - 1325.7 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 178 us
+  ignition-type: *id002
+  temperature:
+  - 1268.7 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 196 us
+  ignition-type: *id002
+  temperature:
+  - 1273.2 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 427 us
+  ignition-type: *id002
+  temperature:
+  - 1215.2 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 649 us
+  ignition-type: *id002
+  temperature:
+  - 1172.4 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 592 us
+  ignition-type: *id002
+  temperature:
+  - 1157.9 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1698 us
+  ignition-type: *id002
+  temperature:
+  - 1088 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3090 us
+  ignition-type: *id002
+  temperature:
+  - 1047.8 kelvin
+  pressure:
+  - 6.5 bar
+  equivalence-ratio: 1

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-4.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-4.yaml
@@ -1,0 +1,276 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 129 us
+  ignition-type: *id002
+  temperature:
+  - 1273.5 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 283 us
+  ignition-type: *id002
+  temperature:
+  - 1186.4 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 291 us
+  ignition-type: *id002
+  temperature:
+  - 1176.3 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 420 us
+  ignition-type: *id002
+  temperature:
+  - 1132.5 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 524 us
+  ignition-type: *id002
+  temperature:
+  - 1131.3 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 794 us
+  ignition-type: *id002
+  temperature:
+  - 1101.4 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 954 us
+  ignition-type: *id002
+  temperature:
+  - 1066.8 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1483 us
+  ignition-type: *id002
+  temperature:
+  - 1025.7 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3478 us
+  ignition-type: *id002
+  temperature:
+  - 944.66 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 5215 us
+  ignition-type: *id002
+  temperature:
+  - 944.6 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 4341 us
+  ignition-type: *id002
+  temperature:
+  - 940.14 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3354 us
+  ignition-type: *id002
+  temperature:
+  - 934.85 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3763 us
+  ignition-type: *id002
+  temperature:
+  - 930.19 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 6402 us
+  ignition-type: *id002
+  temperature:
+  - 906.46 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 6588 us
+  ignition-type: *id002
+  temperature:
+  - 885.85 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3340 us
+  ignition-type: *id002
+  temperature:
+  - 841.09 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3154 us
+  ignition-type: *id002
+  temperature:
+  - 830.34 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 2888 us
+  ignition-type: *id002
+  temperature:
+  - 784.31 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3275 us
+  ignition-type: *id002
+  temperature:
+  - 746.81 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3093 us
+  ignition-type: *id002
+  temperature:
+  - 737.8 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3022 us
+  ignition-type: *id002
+  temperature:
+  - 731.23 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 4804 us
+  ignition-type: *id002
+  temperature:
+  - 699.42 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 4048 us
+  ignition-type: *id002
+  temperature:
+  - 698.67 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 5240 us
+  ignition-type: *id002
+  temperature:
+  - 695.45 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 11265 us
+  ignition-type: *id002
+  temperature:
+  - 676.9 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 13068 us
+  ignition-type: *id002
+  temperature:
+  - 664.19 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 1

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-5.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-5.yaml
@@ -1,0 +1,96 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1311 us
+  ignition-type: *id002
+  temperature:
+  - 999.45 kelvin
+  pressure:
+  - 19.3 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 2580 us
+  ignition-type: *id002
+  temperature:
+  - 929.5 kelvin
+  pressure:
+  - 19.3 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1903 us
+  ignition-type: *id002
+  temperature:
+  - 882.31 kelvin
+  pressure:
+  - 19.3 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1657 us
+  ignition-type: *id002
+  temperature:
+  - 823.2 kelvin
+  pressure:
+  - 19.3 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1474 us
+  ignition-type: *id002
+  temperature:
+  - 789.57 kelvin
+  pressure:
+  - 19.3 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1701 us
+  ignition-type: *id002
+  temperature:
+  - 744.24 kelvin
+  pressure:
+  - 19.3 bar
+  equivalence-ratio: 1

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-6.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-6.yaml
@@ -1,0 +1,78 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 487 us
+  ignition-type: *id002
+  temperature:
+  - 1062.2 kelvin
+  pressure:
+  - 30 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1045 us
+  ignition-type: *id002
+  temperature:
+  - 952.74 kelvin
+  pressure:
+  - 30 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 737 us
+  ignition-type: *id002
+  temperature:
+  - 845.72 kelvin
+  pressure:
+  - 30 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1742 us
+  ignition-type: *id002
+  temperature:
+  - 735.76 kelvin
+  pressure:
+  - 30 bar
+  equivalence-ratio: 1

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-7.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-7.yaml
@@ -1,0 +1,96 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 264 us
+  ignition-type: *id002
+  temperature:
+  - 1064.7 kelvin
+  pressure:
+  - 42 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 560 us
+  ignition-type: *id002
+  temperature:
+  - 981.26 kelvin
+  pressure:
+  - 42 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 564 us
+  ignition-type: *id002
+  temperature:
+  - 942.63 kelvin
+  pressure:
+  - 42 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 552 us
+  ignition-type: *id002
+  temperature:
+  - 916.58 kelvin
+  pressure:
+  - 42 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 395 us
+  ignition-type: *id002
+  temperature:
+  - 866.68 kelvin
+  pressure:
+  - 42 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 455 us
+  ignition-type: *id002
+  temperature:
+  - 813.4 kelvin
+  pressure:
+  - 42 bar
+  equivalence-ratio: 1

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-8.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-8.yaml
@@ -1,0 +1,195 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.036792
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.202354
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.760854
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 185 us
+  ignition-type: *id002
+  temperature:
+  - 1228 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 229 us
+  ignition-type: *id002
+  temperature:
+  - 1210.7 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 245 us
+  ignition-type: *id002
+  temperature:
+  - 1193.5 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 576 us
+  ignition-type: *id002
+  temperature:
+  - 1117.4 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 1926 us
+  ignition-type: *id002
+  temperature:
+  - 1007.8 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 3032 us
+  ignition-type: *id002
+  temperature:
+  - 970.71 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 3464 us
+  ignition-type: *id002
+  temperature:
+  - 968.59 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 3861 us
+  ignition-type: *id002
+  temperature:
+  - 913.18 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 3834 us
+  ignition-type: *id002
+  temperature:
+  - 893.31 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 2256 us
+  ignition-type: *id002
+  temperature:
+  - 831.21 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 2160 us
+  ignition-type: *id002
+  temperature:
+  - 808.27 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 1815 us
+  ignition-type: *id002
+  temperature:
+  - 786.14 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 2535 us
+  ignition-type: *id002
+  temperature:
+  - 748.03 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 5050 us
+  ignition-type: *id002
+  temperature:
+  - 716.18 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 6968 us
+  ignition-type: *id002
+  temperature:
+  - 693.45 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 6559 us
+  ignition-type: *id002
+  temperature:
+  - 691.19 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2
+- composition: *id001
+  ignition-delay:
+  - 7483 us
+  ignition-type: *id002
+  temperature:
+  - 686.84 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 2

--- a/n-heptane/Ciezki 1993/st_ciezki_1993-9.yaml
+++ b/n-heptane/Ciezki 1993/st_ciezki_1993-9.yaml
@@ -1,0 +1,123 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: H.K. Ciezki
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1993
+  volume: 93
+  pages: 421-433
+  doi: 10.1016/0010-2180(93)90142-P
+  detail: Converted from ReSpecTh XML file st_ciezki_1993-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.054191
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.198699
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.74711
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 104 us
+  ignition-type: *id002
+  temperature:
+  - 1280.3 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 273 us
+  ignition-type: *id002
+  temperature:
+  - 1178.1 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 631 us
+  ignition-type: *id002
+  temperature:
+  - 1093.1 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 1517 us
+  ignition-type: *id002
+  temperature:
+  - 1011.3 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 2722 us
+  ignition-type: *id002
+  temperature:
+  - 942.79 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 1970 us
+  ignition-type: *id002
+  temperature:
+  - 903.53 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 1711 us
+  ignition-type: *id002
+  temperature:
+  - 868.83 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 1302 us
+  ignition-type: *id002
+  temperature:
+  - 833.31 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3
+- composition: *id001
+  ignition-delay:
+  - 2683 us
+  ignition-type: *id002
+  temperature:
+  - 738.34 kelvin
+  pressure:
+  - 13.5 bar
+  equivalence-ratio: 3

--- a/n-heptane/Colket 2001/st_colket_2001-1.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-1.yaml
@@ -1,14 +1,14 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-      - name: Meredith B. Colket
-      - name: Louis J. Spadaccini
+    - name: Meredith B. Colket
+    - name: Louis J. Spadaccini
   journal: Journal of Propulsion and Power
   year: 2001
   pages: 315-323
@@ -18,9 +18,8 @@ reference:
 experiment-type: ignition delay
 apparatus:
   facility: ''
-  institution: ''
+  institution: United Technologies Research Center
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -49,6 +48,7 @@ datapoints:
   - 7.7200e+00 atm
   temperature:
   - 1.3930e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.4500e+02 us
@@ -57,6 +57,7 @@ datapoints:
   - 7.7800e+00 atm
   temperature:
   - 1.2990e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 6.3100e+02 us
@@ -65,6 +66,7 @@ datapoints:
   - 7.0400e+00 atm
   temperature:
   - 1.2350e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.4800e+02 us
@@ -73,6 +75,7 @@ datapoints:
   - 6.3800e+00 atm
   temperature:
   - 1.2990e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.3400e+02 us
@@ -81,6 +84,7 @@ datapoints:
   - 7.5300e+00 atm
   temperature:
   - 1.3720e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 6.7800e+02 us
@@ -89,6 +93,7 @@ datapoints:
   - 6.0800e+00 atm
   temperature:
   - 1.2360e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.4800e+02 us
@@ -97,6 +102,7 @@ datapoints:
   - 7.3500e+00 atm
   temperature:
   - 1.3400e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.1100e+02 us
@@ -105,6 +111,7 @@ datapoints:
   - 6.6300e+00 atm
   temperature:
   - 1.3280e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 8.9000e+01 us
@@ -113,6 +120,7 @@ datapoints:
   - 6.9400e+00 atm
   temperature:
   - 1.3950e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 4.1700e+02 us
@@ -121,6 +129,7 @@ datapoints:
   - 4.8800e+00 atm
   temperature:
   - 1.2890e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.7600e+02 us
@@ -129,6 +138,7 @@ datapoints:
   - 5.5300e+00 atm
   temperature:
   - 1.3830e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.1400e+02 us
@@ -137,6 +147,7 @@ datapoints:
   - 6.0900e+00 atm
   temperature:
   - 1.4030e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.7200e+02 us
@@ -145,6 +156,7 @@ datapoints:
   - 5.5000e+00 atm
   temperature:
   - 1.3340e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.8400e+02 us
@@ -153,6 +165,7 @@ datapoints:
   - 5.1300e+00 atm
   temperature:
   - 1.3040e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 7.7300e+02 us
@@ -161,6 +174,7 @@ datapoints:
   - 4.6200e+00 atm
   temperature:
   - 1.2290e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.4200e+02 us
@@ -169,6 +183,7 @@ datapoints:
   - 5.8700e+00 atm
   temperature:
   - 1.3440e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 8.3200e+02 us
@@ -177,6 +192,7 @@ datapoints:
   - 4.8300e+00 atm
   temperature:
   - 1.2380e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 8.4400e+02 us
@@ -185,6 +201,7 @@ datapoints:
   - 4.3600e+00 atm
   temperature:
   - 1.2230e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 5.0400e+02 us
@@ -193,6 +210,7 @@ datapoints:
   - 4.8500e+00 atm
   temperature:
   - 1.2970e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.7600e+02 us
@@ -201,6 +219,7 @@ datapoints:
   - 5.6300e+00 atm
   temperature:
   - 1.3670e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 4.9300e+02 us
@@ -209,5 +228,6 @@ datapoints:
   - 5.4400e+00 atm
   temperature:
   - 1.2900e+03 K
+  equivalence-ratio: 0.5
 
 

--- a/n-heptane/Colket 2001/st_colket_2001-1.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-1.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
       - name: Meredith B. Colket

--- a/n-heptane/Colket 2001/st_colket_2001-1.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Colket 2001/st_colket_2001-1.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-1.yaml
@@ -1,0 +1,210 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+      - name: Meredith B. Colket
+      - name: Louis J. Spadaccini
+  journal: Journal of Propulsion and Power
+  year: 2001
+  pages: 315-323
+  volume: 17
+  detail: Converted from ReSpecTh XML file st_colket_2001-1.xml
+  doi: 10.2514/2.5744
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.00192
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.04224
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.95584
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 8.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 7.7200e+00 atm
+  temperature:
+  - 1.3930e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.4500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 7.7800e+00 atm
+  temperature:
+  - 1.2990e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 7.0400e+00 atm
+  temperature:
+  - 1.2350e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.4800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.3800e+00 atm
+  temperature:
+  - 1.2990e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 7.5300e+00 atm
+  temperature:
+  - 1.3720e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.7800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.0800e+00 atm
+  temperature:
+  - 1.2360e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 7.3500e+00 atm
+  temperature:
+  - 1.3400e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.6300e+00 atm
+  temperature:
+  - 1.3280e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.9000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 6.9400e+00 atm
+  temperature:
+  - 1.3950e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.1700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8800e+00 atm
+  temperature:
+  - 1.2890e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.5300e+00 atm
+  temperature:
+  - 1.3830e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.0900e+00 atm
+  temperature:
+  - 1.4030e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.5000e+00 atm
+  temperature:
+  - 1.3340e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.8400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.1300e+00 atm
+  temperature:
+  - 1.3040e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.7300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.6200e+00 atm
+  temperature:
+  - 1.2290e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.4200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.8700e+00 atm
+  temperature:
+  - 1.3440e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8300e+00 atm
+  temperature:
+  - 1.2380e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.4400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.3600e+00 atm
+  temperature:
+  - 1.2230e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.0400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8500e+00 atm
+  temperature:
+  - 1.2970e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.6300e+00 atm
+  temperature:
+  - 1.3670e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.9300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.4400e+00 atm
+  temperature:
+  - 1.2900e+03 K
+
+

--- a/n-heptane/Colket 2001/st_colket_2001-2.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-2.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
       - name: Meredith B. Colket

--- a/n-heptane/Colket 2001/st_colket_2001-2.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Colket 2001/st_colket_2001-2.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-2.yaml
@@ -1,0 +1,129 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+      - name: Meredith B. Colket
+      - name: Louis J. Spadaccini
+  journal: Journal of Propulsion and Power
+  year: 2001
+  pages: 315-323
+  volume: 17
+  detail: Converted from ReSpecTh XML file st_colket_2001-2.xml
+  doi: 10.2514/2.5744
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.00192
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.02112
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.97696
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 8.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 7.7200e+00 atm
+  temperature:
+  - 1.3930e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 7.2200e+00 atm
+  temperature:
+  - 1.4270e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.4200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.4500e+00 atm
+  temperature:
+  - 1.3320e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.5500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 7.0800e+00 atm
+  temperature:
+  - 1.4130e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.9300e+00 atm
+  temperature:
+  - 1.3870e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.9700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.7700e+00 atm
+  temperature:
+  - 1.2800e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.5600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.8300e+00 atm
+  temperature:
+  - 1.3450e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.5100e+00 atm
+  temperature:
+  - 1.4060e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.6800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.1600e+00 atm
+  temperature:
+  - 1.3260e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.1900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.4600e+00 atm
+  temperature:
+  - 1.3560e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.0000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.1000e+00 atm
+  temperature:
+  - 1.3480e+03 K
+

--- a/n-heptane/Colket 2001/st_colket_2001-2.yaml
+++ b/n-heptane/Colket 2001/st_colket_2001-2.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,9 +18,8 @@ reference:
 experiment-type: ignition delay
 apparatus:
   facility: ''
-  institution: ''
+  institution: United Technologies Research Center
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -49,6 +48,7 @@ datapoints:
   - 7.7200e+00 atm
   temperature:
   - 1.3930e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.2300e+02 us
@@ -57,6 +57,7 @@ datapoints:
   - 7.2200e+00 atm
   temperature:
   - 1.4270e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.4200e+02 us
@@ -65,6 +66,7 @@ datapoints:
   - 6.4500e+00 atm
   temperature:
   - 1.3320e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.5500e+02 us
@@ -73,6 +75,7 @@ datapoints:
   - 7.0800e+00 atm
   temperature:
   - 1.4130e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.7600e+02 us
@@ -81,6 +84,7 @@ datapoints:
   - 6.9300e+00 atm
   temperature:
   - 1.3870e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 7.9700e+02 us
@@ -89,6 +93,7 @@ datapoints:
   - 5.7700e+00 atm
   temperature:
   - 1.2800e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.5600e+02 us
@@ -97,6 +102,7 @@ datapoints:
   - 5.8300e+00 atm
   temperature:
   - 1.3450e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.3100e+02 us
@@ -105,6 +111,7 @@ datapoints:
   - 4.5100e+00 atm
   temperature:
   - 1.4060e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.6800e+02 us
@@ -113,6 +120,7 @@ datapoints:
   - 4.1600e+00 atm
   temperature:
   - 1.3260e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.1900e+02 us
@@ -121,6 +129,7 @@ datapoints:
   - 4.4600e+00 atm
   temperature:
   - 1.3560e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.0000e+02 us
@@ -129,4 +138,5 @@ datapoints:
   - 4.1000e+00 atm
   temperature:
   - 1.3480e+03 K
+  equivalence-ratio: 1.0
 

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: R. Di Sante

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
@@ -1,0 +1,89 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: R. Di Sante
+  detail: Converted from ReSpecTh XML file rcm_disante_2012-1.xml
+  doi: 10.1016/j.combustflame.2011.05.020
+  journal: Combustion and Flame
+  pages: 55-63
+  volume: 159
+  year: 2012
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: rapid compression machine
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01869
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2056
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.7757
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.2 ms
+  ignition-type: *id002
+  pressure:
+  - 9.57 bar
+  temperature:
+  - 711 K
+- composition: *id001
+  ignition-delay:
+  - 2.38 ms
+  ignition-type: *id002
+  pressure:
+  - 10.03 bar
+  temperature:
+  - 732 K
+- composition: *id001
+  ignition-delay:
+  - 2. ms
+  ignition-type: *id002
+  pressure:
+  - 10.12 bar
+  temperature:
+  - 751 K
+- composition: *id001
+  ignition-delay:
+  - 1.83 ms
+  ignition-type: *id002
+  pressure:
+  - 10.4 bar
+  temperature:
+  - 770 K
+- composition: *id001
+  ignition-delay:
+  - 1.6 ms
+  ignition-type: *id002
+  pressure:
+  - 10.67 bar
+  temperature:
+  - 780 K
+- composition: *id001
+  ignition-delay:
+  - 1.33 ms
+  ignition-type: *id002
+  pressure:
+  - 10.90 bar
+  temperature:
+  - 811 K
+
+

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-1.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -16,10 +16,9 @@ reference:
   year: 2012
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: MIT RCM
+  institution: Sloan Automotive Laboratory, M.I.T.
   kind: rapid compression machine
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -43,50 +42,68 @@ datapoints:
 - composition: *id001
   ignition-delay:
   - 4.2 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 9.57 bar
   temperature:
   - 711 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.38 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 10.03 bar
   temperature:
   - 732 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2. ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 10.12 bar
   temperature:
   - 751 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.83 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 10.4 bar
   temperature:
   - 770 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.6 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 10.67 bar
   temperature:
   - 780 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.33 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 10.90 bar
   temperature:
   - 811 K
+  equivalence-ratio: 1.0
 
 

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -16,8 +16,8 @@ reference:
   year: 2012
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: MIT RCM
+  institution: Sloan Automotive Laboratory, M.I.T.
   kind: rapid compression machine
 common-properties:
   composition: &id001
@@ -42,48 +42,66 @@ datapoints:
 - composition: *id001
   ignition-delay:
   - 3.75 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 7.99 bar
   temperature:
   - 718 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.2 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 8.21 bar
   temperature:
   - 729 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.4 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 8.46 bar
   temperature:
   - 749 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.66 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 8.67 bar
   temperature:
   - 769 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.6 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 8.91 bar
   temperature:
   - 782 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.86 ms
+  - uncertainty-type: absolute
+    uncertainty: 0.15 ms
   ignition-type: *id002
   pressure:
   - 9.16 bar
   temperature:
   - 800 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: R. Di Sante
@@ -15,7 +17,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: rapid compression machine
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
+++ b/n-heptane/Di Sante 2012/rcm_disante_2012-2.yaml
@@ -1,0 +1,86 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: R. Di Sante
+  detail: Converted from ReSpecTh XML file rcm_disante_2012-2.xml
+  doi: 10.1016/j.combustflame.2011.05.020
+  journal: Combustion and Flame
+  pages: 55-63
+  volume: 159
+  year: 2012
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: rapid compression machine
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01869
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2056
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.7757
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 3.75 ms
+  ignition-type: *id002
+  pressure:
+  - 7.99 bar
+  temperature:
+  - 718 K
+- composition: *id001
+  ignition-delay:
+  - 3.2 ms
+  ignition-type: *id002
+  pressure:
+  - 8.21 bar
+  temperature:
+  - 729 K
+- composition: *id001
+  ignition-delay:
+  - 3.4 ms
+  ignition-type: *id002
+  pressure:
+  - 8.46 bar
+  temperature:
+  - 749 K
+- composition: *id001
+  ignition-delay:
+  - 3.66 ms
+  ignition-type: *id002
+  pressure:
+  - 8.67 bar
+  temperature:
+  - 769 K
+- composition: *id001
+  ignition-delay:
+  - 2.6 ms
+  ignition-type: *id002
+  pressure:
+  - 8.91 bar
+  temperature:
+  - 782 K
+- composition: *id001
+  ignition-delay:
+  - 1.86 ms
+  ignition-type: *id002
+  pressure:
+  - 9.16 bar
+  temperature:
+  - 800 K

--- a/n-heptane/Fieweger 1997/st_fieweger_1997.yaml
+++ b/n-heptane/Fieweger 1997/st_fieweger_1997.yaml
@@ -1,0 +1,153 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: K. Fieweger
+    - name: R. Blumenthal
+    - name: G. Adomeit
+  journal: Combustion and Flame
+  year: 1997
+  volume: 109
+  pages: 599-619
+  doi: 10.1016/S0010-2180(97)00049-7
+  detail: Converted from ReSpecTh XML file st_fieweger_1997.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: RWTH Aachen University
+  facility: ''
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1000 us
+  ignition-type: *id002
+  temperature:
+  - 752 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 580 us
+  ignition-type: *id002
+  temperature:
+  - 787 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 480 us
+  ignition-type: *id002
+  temperature:
+  - 813 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 400 us
+  ignition-type: *id002
+  temperature:
+  - 870 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 495 us
+  ignition-type: *id002
+  temperature:
+  - 881 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 535 us
+  ignition-type: *id002
+  temperature:
+  - 917 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 550 us
+  ignition-type: *id002
+  temperature:
+  - 947 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 550 us
+  ignition-type: *id002
+  temperature:
+  - 984 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 288 us
+  ignition-type: *id002
+  temperature:
+  - 1064 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 90 us
+  ignition-type: *id002
+  temperature:
+  - 1143 K
+  pressure:
+  - 40 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
+  equivalence-ratio: 1

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: B.M. Gauthier

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
@@ -1,0 +1,87 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: B.M. Gauthier
+  - name: D.F. Davidson
+  - name: R.K. Hanson
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-1.xml
+  doi: 10.1016/j.combustflame.2004.08.015
+  journal: Combustion and Flame
+  pages: 300-311
+  volume: 139
+  year: 2004
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 5.2900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.9700e+00 atm
+  temperature:
+  - 1.2490e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.1100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8900e+00 atm
+  temperature:
+  - 1.2990e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.5200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8500e+00 atm
+  temperature:
+  - 1.3580e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1700e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9900e+00 atm
+  temperature:
+  - 1.3780e+03 K
+experiment-type: ignition delay
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: B.M. Gauthier
+  - name: D.F. Davidson
+  - name: R.K. Hanson
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-1.xml
+  doi: 10.1016/j.combustflame.2004.08.015
+  journal: Combustion and Flame
+  pages: 300-311
+  volume: 139
+  year: 2004

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-1.yaml
@@ -1,26 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: B.M. Gauthier
-  - name: D.F. Davidson
-  - name: R.K. Hanson
-  detail: Converted from ReSpecTh XML file st_gauthier_2004-1.xml
-  doi: 10.1016/j.combustflame.2004.08.015
+    - name: B. M. Gauthier
+    - name: D. F. Davidson
+    - name: R. K. Hanson
   journal: Combustion and Flame
-  pages: 300-311
-  volume: 139
   year: 2004
+  volume: 139
+  pages: 300-311
+  doi: 10.1016/j.combustflame.2004.08.015
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-1.xml
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
   kind: shock tube
+  institution: Stanford University
+  facility: low pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -40,51 +40,56 @@ common-properties:
   ignition-type: &id002
     target: pressure
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 5.2900e+02 us
+  - 529 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.9700e+00 atm
   temperature:
-  - 1.2490e+03 K
+  - 1249 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 1.97 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 3.1100e+02 us
+  - 311 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.8900e+00 atm
   temperature:
-  - 1.2990e+03 K
+  - 1299 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 1.89 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.5200e+02 us
+  - 152 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.8500e+00 atm
   temperature:
-  - 1.3580e+03 K
+  - 1358 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 1.85 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.1700e+01 us
+  - 117 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.9900e+00 atm
   temperature:
-  - 1.3780e+03 K
-experiment-type: ignition delay
-file-author:
-  name: KE Niemeyer, Oregon State University
-file-version: 0
-reference:
-  authors:
-  - name: B.M. Gauthier
-  - name: D.F. Davidson
-  - name: R.K. Hanson
-  detail: Converted from ReSpecTh XML file st_gauthier_2004-1.xml
-  doi: 10.1016/j.combustflame.2004.08.015
-  journal: Combustion and Flame
-  pages: 300-311
-  volume: 139
-  year: 2004
+  - 1378 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 1.99 bar
+  equivalence-ratio: 1

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: B.M. Gauthier

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
@@ -1,26 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: B.M. Gauthier
-  - name: D.F. Davidson
-  - name: R.K. Hanson
-  detail: Converted from ReSpecTh XML file st_gauthier_2004-2.xml
-  doi: 10.1016/j.combustflame.2004.08.015
+    - name: B. M. Gauthier
+    - name: D. F. Davidson
+    - name: R. K. Hanson
   journal: Combustion and Flame
-  pages: 300-311
-  volume: 139
   year: 2004
+  volume: 139
+  pages: 300-311
+  doi: 10.1016/j.combustflame.2004.08.015
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-2.xml
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
   kind: shock tube
+  institution: Stanford University
+  facility: high pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -40,44 +40,69 @@ common-properties:
   ignition-type: &id002
     target: pressure
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 1.1700e+02 us
+  - 117 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.0620e+01 atm
   temperature:
-  - 1.3050e+03 K
+  - 1305 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 10.62 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 2.0700e+02 us
+  - 207 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.1240e+01 atm
   temperature:
-  - 1.2360e+03 K
+  - 1236 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 11.24 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.2200e+02 us
+  - 122 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.0250e+01 atm
   temperature:
-  - 1.2990e+03 K
+  - 1299 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 10.25 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 8.5000e+01 us
+  - 85 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.0270e+01 atm
   temperature:
-  - 1.3440e+03 K
+  - 1344 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 10.27 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.1800e+02 us
+  - 118 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.1880e+01 atm
   temperature:
-  - 1.2900e+03 K
+  - 1290 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 11.88 bar
+  equivalence-ratio: 1

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-2.yaml
@@ -1,0 +1,80 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: B.M. Gauthier
+  - name: D.F. Davidson
+  - name: R.K. Hanson
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-2.xml
+  doi: 10.1016/j.combustflame.2004.08.015
+  journal: Combustion and Flame
+  pages: 300-311
+  volume: 139
+  year: 2004
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.1700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0620e+01 atm
+  temperature:
+  - 1.3050e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1240e+01 atm
+  temperature:
+  - 1.2360e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0250e+01 atm
+  temperature:
+  - 1.2990e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.0270e+01 atm
+  temperature:
+  - 1.3440e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1880e+01 atm
+  temperature:
+  - 1.2900e+03 K

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
@@ -1,26 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: B.M. Gauthier
-  - name: D.F. Davidson
-  - name: R.K. Hanson
-  detail: Converted from ReSpecTh XML file st_gauthier_2004-3.xml
-  doi: 10.1016/j.combustflame.2004.08.015
+    - name: B. M. Gauthier
+    - name: D. F. Davidson
+    - name: R. K. Hanson
   journal: Combustion and Flame
-  pages: 300-311
-  volume: 139
   year: 2004
+  volume: 139
+  pages: 300-311
+  doi: 10.1016/j.combustflame.2004.08.015
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-3.xml
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
   kind: shock tube
+  institution: Stanford University
+  facility: high pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -40,44 +40,69 @@ common-properties:
   ignition-type: &id002
     target: pressure
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 1.3770e+03 us
+  - 1377 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 2.0000e+01 atm
   temperature:
-  - 8.0600e+02 K
+  - 806 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 20 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.6530e+03 us
+  - 1653 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.9900e+01 atm
   temperature:
-  - 8.5000e+02 K
+  - 850 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 19.9 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.8360e+03 us
+  - 1836 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.9800e+01 atm
   temperature:
-  - 9.0600e+02 K
+  - 906 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 19.8 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 9.4400e+02 us
+  - 944 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.8100e+01 atm
   temperature:
-  - 1.0120e+03 K
+  - 1012 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 18.1 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 8.5400e+02 us
+  - 854 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 1.6700e+01 atm
   temperature:
-  - 1.0480e+03 K
+  - 1048 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 16.7 bar
+  equivalence-ratio: 1

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: B.M. Gauthier

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-3.yaml
@@ -1,0 +1,80 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: B.M. Gauthier
+  - name: D.F. Davidson
+  - name: R.K. Hanson
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-3.xml
+  doi: 10.1016/j.combustflame.2004.08.015
+  journal: Combustion and Flame
+  pages: 300-311
+  volume: 139
+  year: 2004
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.3770e+03 us
+  ignition-type: *id002
+  pressure:
+  - 2.0000e+01 atm
+  temperature:
+  - 8.0600e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.6530e+03 us
+  ignition-type: *id002
+  pressure:
+  - 1.9900e+01 atm
+  temperature:
+  - 8.5000e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.8360e+03 us
+  ignition-type: *id002
+  pressure:
+  - 1.9800e+01 atm
+  temperature:
+  - 9.0600e+02 K
+- composition: *id001
+  ignition-delay:
+  - 9.4400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8100e+01 atm
+  temperature:
+  - 1.0120e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.5400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.6700e+01 atm
+  temperature:
+  - 1.0480e+03 K

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
@@ -1,26 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: B.M. Gauthier
-  - name: D.F. Davidson
-  - name: R.K. Hanson
-  detail: Converted from ReSpecTh XML file st_gauthier_2004-4.xml
-  doi: 10.1016/j.combustflame.2004.08.015
+    - name: B. M. Gauthier
+    - name: D. F. Davidson
+    - name: R. K. Hanson
   journal: Combustion and Flame
-  pages: 300-311
-  volume: 139
   year: 2004
+  volume: 139
+  pages: 300-311
+  doi: 10.1016/j.combustflame.2004.08.015
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-4.xml
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
   kind: shock tube
+  institution: Stanford University
+  facility: high pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -40,100 +40,160 @@ common-properties:
   ignition-type: &id002
     target: pressure
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 2.5400e+02 us
+  - 254 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.3900e+01 atm
   temperature:
-  - 9.0900e+02 K
+  - 909 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 53.9 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 2.4400e+02 us
+  - 244 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 6.0000e+01 atm
   temperature:
-  - 9.2300e+02 K
+  - 923 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 60 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 2.3300e+02 us
+  - 233 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 6.0600e+01 atm
   temperature:
-  - 9.2600e+02 K
+  - 926 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 60.6 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 3.2300e+02 us
+  - 323 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.5400e+01 atm
   temperature:
-  - 9.3200e+02 K
+  - 932 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 55.4 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 3.6400e+02 us
+  - 364 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 4.8600e+01 atm
   temperature:
-  - 9.8500e+02 K
+  - 985 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 48.6 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 2.3200e+02 us
+  - 232 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.7700e+01 atm
   temperature:
-  - 1.0070e+03 K
+  - 1007 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 57.7 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 2.9200e+02 us
+  - 292 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.3600e+01 atm
   temperature:
-  - 1.0130e+03 K
+  - 1013 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 53.6 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 2.6100e+02 us
+  - 261 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.4200e+01 atm
   temperature:
-  - 1.0230e+03 K
+  - 1023 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 54.2 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 2.3700e+02 us
+  - 237 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.9100e+01 atm
   temperature:
-  - 1.0270e+03 K
+  - 1027 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 59.1 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.9400e+02 us
+  - 194 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.0000e+01 atm
   temperature:
-  - 1.0570e+03 K
+  - 1057 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 50 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.7900e+02 us
+  - 179 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.3100e+01 atm
   temperature:
-  - 1.0630e+03 K
+  - 1063 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 53.1 bar
+  equivalence-ratio: 1
 - composition: *id001
   ignition-delay:
-  - 1.0200e+02 us
+  - 102 us
+  - uncertainty-type: relative
+    uncertainty: 0.15
   ignition-type: *id002
-  pressure:
-  - 5.2300e+01 atm
   temperature:
-  - 1.1150e+03 K
+  - 1115 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.018
+  pressure:
+  - 52.3 bar
+  equivalence-ratio: 1

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
@@ -1,0 +1,136 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: B.M. Gauthier
+  - name: D.F. Davidson
+  - name: R.K. Hanson
+  detail: Converted from ReSpecTh XML file st_gauthier_2004-4.xml
+  doi: 10.1016/j.combustflame.2004.08.015
+  journal: Combustion and Flame
+  pages: 300-311
+  volume: 139
+  year: 2004
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 2.5400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.3900e+01 atm
+  temperature:
+  - 9.0900e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.4400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.0000e+01 atm
+  temperature:
+  - 9.2300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.3300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 6.0600e+01 atm
+  temperature:
+  - 9.2600e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.2300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.5400e+01 atm
+  temperature:
+  - 9.3200e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.6400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8600e+01 atm
+  temperature:
+  - 9.8500e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.7700e+01 atm
+  temperature:
+  - 1.0070e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.9200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.3600e+01 atm
+  temperature:
+  - 1.0130e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.6100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.4200e+01 atm
+  temperature:
+  - 1.0230e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.3700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.9100e+01 atm
+  temperature:
+  - 1.0270e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.9400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0000e+01 atm
+  temperature:
+  - 1.0570e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.3100e+01 atm
+  temperature:
+  - 1.0630e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.0200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.2300e+01 atm
+  temperature:
+  - 1.1150e+03 K

--- a/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
+++ b/n-heptane/Gauthier 2004/st_gauthier_2004-4.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: B.M. Gauthier

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -21,8 +21,8 @@ reference:
   year: 2011
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: high pressure shock tube
+  institution: University of Duisburg-Essen
   kind: shock tube
 common-properties:
   composition: &id001
@@ -50,85 +50,118 @@ datapoints:
   ignition-type: *id002
   pressure:
   - 4.2500e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 7.3900e+02 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 4.3100e+02 us
   ignition-type: *id002
   pressure:
   - 4.2600e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.1200e+02 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 5.2000e+02 us
   ignition-type: *id002
   pressure:
   - 3.8200e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.2600e+02 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 5.5100e+02 us
   ignition-type: *id002
   pressure:
   - 3.8500e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.5300e+02 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 5.5900e+02 us
   ignition-type: *id002
   pressure:
   - 3.6400e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.6000e+02 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 4.2700e+02 us
   ignition-type: *id002
   pressure:
   - 4.2400e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.8500e+02 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 6.0100e+02 us
   ignition-type: *id002
   pressure:
   - 4.3200e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 9.7000e+02 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 5.0500e+02 us
   ignition-type: *id002
   pressure:
   - 4.1400e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.0330e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.1000e+02 us
   ignition-type: *id002
   pressure:
   - 4.5100e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.1650e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.0000e+01 us
   ignition-type: *id002
   pressure:
   - 4.4300e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.2470e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.0000e+01 us
   ignition-type: *id002
   pressure:
   - 4.6700e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.2750e+03 K
+  equivalence-ratio: 0.5

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
@@ -1,0 +1,131 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: M. Hartmann
+  - name: I. Gushterova
+  - name: M. Fikri
+  - name: C. Schulz
+  - name: "R. Schie\xDFl"
+  - name: U. Maas
+  detail: Converted from ReSpecTh XML file st_hartmann_2011-1.xml
+  doi: 10.1016/j.combustflame.2010.08.005
+  journal: Combustion and Flame
+  pages: 172-178
+  volume: 158
+  year: 2011
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.009459
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2081
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.782441
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.5640e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.2500e+01 bar
+  temperature:
+  - 7.3900e+02 K
+- composition: *id001
+  ignition-delay:
+  - 4.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2600e+01 bar
+  temperature:
+  - 8.1200e+02 K
+- composition: *id001
+  ignition-delay:
+  - 5.2000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.8200e+01 bar
+  temperature:
+  - 8.2600e+02 K
+- composition: *id001
+  ignition-delay:
+  - 5.5100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.8500e+01 bar
+  temperature:
+  - 8.5300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 5.5900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.6400e+01 bar
+  temperature:
+  - 8.6000e+02 K
+- composition: *id001
+  ignition-delay:
+  - 4.2700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2400e+01 bar
+  temperature:
+  - 8.8500e+02 K
+- composition: *id001
+  ignition-delay:
+  - 6.0100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.3200e+01 bar
+  temperature:
+  - 9.7000e+02 K
+- composition: *id001
+  ignition-delay:
+  - 5.0500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.1400e+01 bar
+  temperature:
+  - 1.0330e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.5100e+01 bar
+  temperature:
+  - 1.1650e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.4300e+01 bar
+  temperature:
+  - 1.2470e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.0000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.6700e+01 bar
+  temperature:
+  - 1.2750e+03 K

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-1.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: M. Hartmann

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -21,8 +21,8 @@ reference:
   year: 2011
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: high pressure shock tube
+  institution: University of Duisburg-Essen
   kind: shock tube
 common-properties:
   composition: &id001
@@ -50,173 +50,239 @@ datapoints:
   ignition-type: *id002
   pressure:
   - 4.0900e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 6.9200e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.6960e+03 us
   ignition-type: *id002
   pressure:
   - 4.1400e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 6.9500e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.9750e+03 us
   ignition-type: *id002
   pressure:
   - 3.2750e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 7.0500e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.0080e+03 us
   ignition-type: *id002
   pressure:
   - 4.0200e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 7.3500e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.8000e+02 us
   ignition-type: *id002
   pressure:
   - 4.0900e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 7.6700e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.3200e+02 us
   ignition-type: *id002
   pressure:
   - 4.3000e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 7.6900e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.7600e+02 us
   ignition-type: *id002
   pressure:
   - 4.1000e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.2300e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.8600e+02 us
   ignition-type: *id002
   pressure:
   - 3.8000e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.3600e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.1100e+02 us
   ignition-type: *id002
   pressure:
   - 4.3000e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.4100e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.2000e+02 us
   ignition-type: *id002
   pressure:
   - 4.2900e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 8.8000e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.0800e+02 us
   ignition-type: *id002
   pressure:
   - 4.2400e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 9.3300e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.8800e+02 us
   ignition-type: *id002
   pressure:
   - 4.2300e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 9.3700e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.8300e+02 us
   ignition-type: *id002
   pressure:
   - 4.2000e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 9.7000e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.3200e+02 us
   ignition-type: *id002
   pressure:
   - 4.3300e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 9.8400e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.9400e+02 us
   ignition-type: *id002
   pressure:
   - 3.9200e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 9.9000e+02 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.6400e+02 us
   ignition-type: *id002
   pressure:
   - 4.7200e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.0300e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.1900e+02 us
   ignition-type: *id002
   pressure:
   - 4.2800e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.0320e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.9700e+02 us
   ignition-type: *id002
   pressure:
   - 4.3600e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.0400e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.1800e+02 us
   ignition-type: *id002
   pressure:
   - 4.7000e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.0720e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.4000e+01 us
   ignition-type: *id002
   pressure:
   - 4.7500e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.2460e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.2000e+01 us
   ignition-type: *id002
   pressure:
   - 4.7600e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.2490e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.1000e+01 us
   ignition-type: *id002
   pressure:
   - 4.9100e+01 bar
+  - uncertainty-type: absolute
+    uncertainty: 2 bar
   temperature:
   - 1.2640e+03 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
@@ -1,0 +1,219 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: M. Hartmann
+  - name: I. Gushterova
+  - name: M. Fikri
+  - name: C. Schulz
+  - name: "R. Schie\xDFl"
+  - name: U. Maas
+  detail: Converted from ReSpecTh XML file st_hartmann_2011-2.xml
+  doi: 10.1016/j.combustflame.2010.08.005
+  journal: Combustion and Flame
+  pages: 172-178
+  volume: 158
+  year: 2011
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77511
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 3.1480e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.0900e+01 bar
+  temperature:
+  - 6.9200e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.6960e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.1400e+01 bar
+  temperature:
+  - 6.9500e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.9750e+03 us
+  ignition-type: *id002
+  pressure:
+  - 3.2750e+01 bar
+  temperature:
+  - 7.0500e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.0080e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.0200e+01 bar
+  temperature:
+  - 7.3500e+02 K
+- composition: *id001
+  ignition-delay:
+  - 6.8000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.0900e+01 bar
+  temperature:
+  - 7.6700e+02 K
+- composition: *id001
+  ignition-delay:
+  - 6.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.3000e+01 bar
+  temperature:
+  - 7.6900e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.7600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.1000e+01 bar
+  temperature:
+  - 8.2300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.8600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.8000e+01 bar
+  temperature:
+  - 8.3600e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.1100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.3000e+01 bar
+  temperature:
+  - 8.4100e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.2000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2900e+01 bar
+  temperature:
+  - 8.8000e+02 K
+- composition: *id001
+  ignition-delay:
+  - 4.0800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2400e+01 bar
+  temperature:
+  - 9.3300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 4.8800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2300e+01 bar
+  temperature:
+  - 9.3700e+02 K
+- composition: *id001
+  ignition-delay:
+  - 4.8300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2000e+01 bar
+  temperature:
+  - 9.7000e+02 K
+- composition: *id001
+  ignition-delay:
+  - 4.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.3300e+01 bar
+  temperature:
+  - 9.8400e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.9400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 3.9200e+01 bar
+  temperature:
+  - 9.9000e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.6400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.7200e+01 bar
+  temperature:
+  - 1.0300e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.1900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2800e+01 bar
+  temperature:
+  - 1.0320e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.9700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.3600e+01 bar
+  temperature:
+  - 1.0400e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.7000e+01 bar
+  temperature:
+  - 1.0720e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.7500e+01 bar
+  temperature:
+  - 1.2460e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.7600e+01 bar
+  temperature:
+  - 1.2490e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.9100e+01 bar
+  temperature:
+  - 1.2640e+03 K

--- a/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
+++ b/n-heptane/Hartmann 2011/st_hartmann_2011-2.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: M. Hartmann

--- a/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
@@ -1,0 +1,96 @@
+file-author:
+    name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: J. Herzler
+  - name: L. Jerig
+  - name: P. Roth
+  detail: Converted from ReSpecTh XML file st_herzler_2005-1.xml
+  doi: 10.1016/j.proci.2004.07.008
+  journal: Proceedings of the Combustion Institute
+  pages: 1147-1153
+  volume: 30
+  year: 2005
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+experiment-type: ignition delay
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.001906
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.209684
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.78841
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.3800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.9100e+01 bar
+  temperature:
+  - 1.0920e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.4700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.7600e+01 bar
+  temperature:
+  - 1.0480e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.8500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0000e+01 bar
+  temperature:
+  - 1.0170e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2060e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.5500e+01 bar
+  temperature:
+  - 9.7300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.3030e+03 us
+  ignition-type: *id002
+  pressure:
+  - 5.5000e+01 bar
+  temperature:
+  - 9.4300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.3860e+03 us
+  ignition-type: *id002
+  pressure:
+  - 5.1900e+01 bar
+  temperature:
+  - 9.1900e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.2500e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.9500e+01 bar
+  temperature:
+  - 8.6300e+02 K

--- a/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
     name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: J. Herzler

--- a/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-1.yaml
@@ -1,26 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: J. Herzler
-  - name: L. Jerig
-  - name: P. Roth
-  detail: Converted from ReSpecTh XML file st_herzler_2005-1.xml
-  doi: 10.1016/j.proci.2004.07.008
+    - name: J. Herzler
+    - name: L. Jerig
+    - name: P. Roth
   journal: Proceedings of the Combustion Institute
-  pages: 1147-1153
-  volume: 30
   year: 2005
-apparatus:
-  facility: ''
-  institution: ''
-  kind: shock tube
+  volume: 30
+  pages: 1147-1153
+  doi: 10.1016/j.proci.2004.07.008
+  detail: Converted from ReSpecTh XML file st_herzler_2005-1.xml
 experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: University of Duisburg-Essen
+  facility: high-pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -40,60 +40,81 @@ common-properties:
   ignition-type: &id002
     target: CH*
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 4.3800e+02 us
+  - 438 us
   ignition-type: *id002
-  pressure:
-  - 4.9100e+01 bar
   temperature:
-  - 1.0920e+03 K
+  - 1092 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.1 bar
+  equivalence-ratio: 0.1
 - composition: *id001
   ignition-delay:
-  - 6.4700e+02 us
+  - 647 us
   ignition-type: *id002
-  pressure:
-  - 4.7600e+01 bar
   temperature:
-  - 1.0480e+03 K
+  - 1048 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 47.6 bar
+  equivalence-ratio: 0.1
 - composition: *id001
   ignition-delay:
-  - 7.8500e+02 us
+  - 785 us
   ignition-type: *id002
-  pressure:
-  - 5.0000e+01 bar
   temperature:
-  - 1.0170e+03 K
+  - 1017 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50 bar
+  equivalence-ratio: 0.1
 - composition: *id001
   ignition-delay:
-  - 1.2060e+03 us
+  - 1206 us
   ignition-type: *id002
-  pressure:
-  - 4.5500e+01 bar
   temperature:
-  - 9.7300e+02 K
+  - 973 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 45.5 bar
+  equivalence-ratio: 0.1
 - composition: *id001
   ignition-delay:
-  - 1.3030e+03 us
+  - 1303 us
   ignition-type: *id002
-  pressure:
-  - 5.5000e+01 bar
   temperature:
-  - 9.4300e+02 K
+  - 943 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 55 bar
+  equivalence-ratio: 0.1
 - composition: *id001
   ignition-delay:
-  - 1.3860e+03 us
+  - 1386 us
   ignition-type: *id002
-  pressure:
-  - 5.1900e+01 bar
   temperature:
-  - 9.1900e+02 K
+  - 919 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 51.9 bar
+  equivalence-ratio: 0.1
 - composition: *id001
   ignition-delay:
-  - 2.2500e+03 us
+  - 2250 us
   ignition-type: *id002
-  pressure:
-  - 4.9500e+01 bar
   temperature:
-  - 8.6300e+02 K
+  - 863 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.5 bar
+  equivalence-ratio: 0.1

--- a/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
@@ -1,0 +1,112 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: J. Herzler
+  - name: L. Jerig
+  - name: P. Roth
+  detail: Converted from ReSpecTh XML file st_herzler_2005-2.xml
+  doi: 10.1016/j.proci.2004.07.008
+  journal: Proceedings of the Combustion Institute
+  pages: 1147-1153
+  volume: 30
+  year: 2005
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.003805
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.209285
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.78691
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 2.1600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.2900e+01 bar
+  temperature:
+  - 1.1150e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.1800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.7900e+01 bar
+  temperature:
+  - 1.0620e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.3900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.9800e+01 bar
+  temperature:
+  - 1.0430e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.0390e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.9500e+01 bar
+  temperature:
+  - 9.8900e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.3260e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.9900e+01 bar
+  temperature:
+  - 9.3700e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.2870e+03 us
+  ignition-type: *id002
+  pressure:
+  - 5.3200e+01 bar
+  temperature:
+  - 9.1700e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.6170e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.9800e+01 bar
+  temperature:
+  - 8.5600e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.5680e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.7900e+01 bar
+  temperature:
+  - 7.8400e+02 K
+- composition: *id001
+  ignition-delay:
+  - 3.5100e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.9900e+01 bar
+  temperature:
+  - 7.3500e+02 K

--- a/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
@@ -1,7 +1,8 @@
-file-author:
-  name: KE Niemeyer, Oregon State University
+file-authors:
+    name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: J. Herzler

--- a/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-2.yaml
@@ -1,26 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: J. Herzler
-  - name: L. Jerig
-  - name: P. Roth
-  detail: Converted from ReSpecTh XML file st_herzler_2005-2.xml
-  doi: 10.1016/j.proci.2004.07.008
+    - name: J. Herzler
+    - name: L. Jerig
+    - name: P. Roth
   journal: Proceedings of the Combustion Institute
-  pages: 1147-1153
-  volume: 30
   year: 2005
+  volume: 30
+  pages: 1147-1153
+  doi: 10.1016/j.proci.2004.07.008
+  detail: Converted from ReSpecTh XML file st_herzler_2005-2.xml
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
   kind: shock tube
+  institution: University of Duisburg-Essen
+  facility: high-pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -40,76 +40,103 @@ common-properties:
   ignition-type: &id002
     target: CH*
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 2.1600e+02 us
+  - 216 us
   ignition-type: *id002
-  pressure:
-  - 5.2900e+01 bar
   temperature:
-  - 1.1150e+03 K
+  - 1115 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 52.9 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 5.1800e+02 us
+  - 518 us
   ignition-type: *id002
-  pressure:
-  - 4.7900e+01 bar
   temperature:
-  - 1.0620e+03 K
+  - 1062 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 47.9 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 6.3900e+02 us
+  - 639 us
   ignition-type: *id002
-  pressure:
-  - 4.9800e+01 bar
   temperature:
-  - 1.0430e+03 K
+  - 1043 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.8 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 1.0390e+03 us
+  - 1039 us
   ignition-type: *id002
-  pressure:
-  - 4.9500e+01 bar
   temperature:
-  - 9.8900e+02 K
+  - 989 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.5 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 1.3260e+03 us
+  - 1326 us
   ignition-type: *id002
-  pressure:
-  - 4.9900e+01 bar
   temperature:
-  - 9.3700e+02 K
+  - 937 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.9 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 1.2870e+03 us
+  - 1287 us
   ignition-type: *id002
-  pressure:
-  - 5.3200e+01 bar
   temperature:
-  - 9.1700e+02 K
+  - 917 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 53.2 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 1.6170e+03 us
+  - 1617 us
   ignition-type: *id002
-  pressure:
-  - 4.9800e+01 bar
   temperature:
-  - 8.5600e+02 K
+  - 856 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.8 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 2.5680e+03 us
+  - 2568 us
   ignition-type: *id002
-  pressure:
-  - 4.7900e+01 bar
   temperature:
-  - 7.8400e+02 K
+  - 784 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 47.9 bar
+  equivalence-ratio: 0.2
 - composition: *id001
   ignition-delay:
-  - 3.5100e+03 us
+  - 3510 us
   ignition-type: *id002
-  pressure:
-  - 4.9900e+01 bar
   temperature:
-  - 7.3500e+02 K
+  - 735 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.9 bar
+  equivalence-ratio: 0.2

--- a/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
@@ -1,0 +1,97 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: J. Herzler
+  - name: L. Jerig
+  - name: P. Roth
+  detail: Converted from ReSpecTh XML file st_herzler_2005-2.xml
+  doi: 10.1016/j.proci.2004.07.008
+  journal: Proceedings of the Combustion Institute
+  pages: 1147-1153
+  volume: 30
+  year: 2005
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.005697
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.208887
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.785416
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.9600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.9300e+01 bar
+  temperature:
+  - 1.1280e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.8700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0700e+01 bar
+  temperature:
+  - 1.0360e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.7600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8900e+01 bar
+  temperature:
+  - 9.7000e+02 K
+- composition: *id001
+  ignition-delay:
+  - 8.2900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0900e+01 bar
+  temperature:
+  - 8.8800e+02 K
+- composition: *id001
+  ignition-delay:
+  - 9.0600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8800e+01 bar
+  temperature:
+  - 8.3400e+02 K
+- composition: *id001
+  ignition-delay:
+  - 1.1620e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.8800e+01 bar
+  temperature:
+  - 7.7400e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.2620e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.8900e+01 bar
+  temperature:
+  - 7.2200e+02 K

--- a/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
@@ -1,7 +1,8 @@
-file-author:
-  name: KE Niemeyer, Oregon State University
+file-authors:
+    name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: J. Herzler

--- a/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-3.yaml
@@ -1,27 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: J. Herzler
-  - name: L. Jerig
-  - name: P. Roth
-  detail: Converted from ReSpecTh XML file st_herzler_2005-2.xml
-  doi: 10.1016/j.proci.2004.07.008
+    - name: J. Herzler
+    - name: L. Jerig
+    - name: P. Roth
   journal: Proceedings of the Combustion Institute
-  pages: 1147-1153
-  volume: 30
   year: 2005
+  volume: 30
+  pages: 1147-1153
+  doi: 10.1016/j.proci.2004.07.008
+  detail: Converted from ReSpecTh XML file st_herzler_2005-3.xml
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
   kind: shock tube
-chemked-version: 0.3.0
+  institution: University of Duisburg-Essen
+  facility: high-pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -41,60 +40,81 @@ common-properties:
   ignition-type: &id002
     target: CH*
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 1.9600e+02 us
+  - 196 us
   ignition-type: *id002
-  pressure:
-  - 4.9300e+01 bar
   temperature:
-  - 1.1280e+03 K
+  - 1128 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 49.3 bar
+  equivalence-ratio: 0.3
 - composition: *id001
   ignition-delay:
-  - 4.8700e+02 us
+  - 487 us
   ignition-type: *id002
-  pressure:
-  - 5.0700e+01 bar
   temperature:
-  - 1.0360e+03 K
+  - 1036 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50.7 bar
+  equivalence-ratio: 0.3
 - composition: *id001
   ignition-delay:
-  - 7.7600e+02 us
+  - 776 us
   ignition-type: *id002
-  pressure:
-  - 4.8900e+01 bar
   temperature:
-  - 9.7000e+02 K
+  - 970 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 48.9 bar
+  equivalence-ratio: 0.3
 - composition: *id001
   ignition-delay:
-  - 8.2900e+02 us
+  - 829 us
   ignition-type: *id002
-  pressure:
-  - 5.0900e+01 bar
   temperature:
-  - 8.8800e+02 K
+  - 888 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50.9 bar
+  equivalence-ratio: 0.3
 - composition: *id001
   ignition-delay:
-  - 9.0600e+02 us
+  - 906 us
   ignition-type: *id002
-  pressure:
-  - 4.8800e+01 bar
   temperature:
-  - 8.3400e+02 K
+  - 834 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 48.8 bar
+  equivalence-ratio: 0.3
 - composition: *id001
   ignition-delay:
-  - 1.1620e+03 us
+  - 1162 us
   ignition-type: *id002
-  pressure:
-  - 4.8800e+01 bar
   temperature:
-  - 7.7400e+02 K
+  - 774 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 48.8 bar
+  equivalence-ratio: 0.3
 - composition: *id001
   ignition-delay:
-  - 2.2620e+03 us
+  - 2262 us
   ignition-type: *id002
-  pressure:
-  - 4.8900e+01 bar
   temperature:
-  - 7.2200e+02 K
+  - 722 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 48.9 bar
+  equivalence-ratio: 0.3

--- a/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
@@ -1,0 +1,122 @@
+
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: J. Herzler
+  - name: L. Jerig
+  - name: P. Roth
+  detail: Converted from ReSpecTh XML file st_herzler_2005-2.xml
+  doi: 10.1016/j.proci.2004.07.008
+  journal: Proceedings of the Combustion Institute
+  pages: 1147-1153
+  volume: 30
+  year: 2005
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.00758
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20849
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.78393
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.7000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8200e+01 bar
+  temperature:
+  - 1.1000e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.8600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.1500e+01 bar
+  temperature:
+  - 1.0670e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.3900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0300e+01 bar
+  temperature:
+  - 1.0180e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.4800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0700e+01 bar
+  temperature:
+  - 9.7300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 6.4600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0700e+01 bar
+  temperature:
+  - 9.7300e+02 K
+- composition: *id001
+  ignition-delay:
+  - 7.2300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.7500e+01 bar
+  temperature:
+  - 9.4500e+02 K
+- composition: *id001
+  ignition-delay:
+  - 6.0600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0900e+01 bar
+  temperature:
+  - 8.7700e+02 K
+- composition: *id001
+  ignition-delay:
+  - 6.8800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.8900e+01 bar
+  temperature:
+  - 8.2500e+02 K
+- composition: *id001
+  ignition-delay:
+  - 8.5500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.0800e+01 bar
+  temperature:
+  - 7.7900e+02 K
+- composition: *id001
+  ignition-delay:
+  - 2.1560e+03 us
+  ignition-type: *id002
+  pressure:
+  - 4.7900e+01 bar
+  temperature:
+  - 7.2600e+02 K

--- a/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
@@ -1,6 +1,8 @@
 file-authors:
-    name: KE Niemeyer, Oregon State University
-    name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
@@ -1,27 +1,26 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
   authors:
-  - name: J. Herzler
-  - name: L. Jerig
-  - name: P. Roth
-  detail: Converted from ReSpecTh XML file st_herzler_2005-2.xml
-  doi: 10.1016/j.proci.2004.07.008
+    - name: J. Herzler
+    - name: L. Jerig
+    - name: P. Roth
   journal: Proceedings of the Combustion Institute
-  pages: 1147-1153
-  volume: 30
   year: 2005
+  volume: 30
+  pages: 1147-1153
+  doi: 10.1016/j.proci.2004.07.008
+  detail: Converted from ReSpecTh XML file st_herzler_2005-4.xml
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
   kind: shock tube
-chemked-version: 0.3.0
+  institution: University of Duisburg-Essen
+  facility: high-pressure shock tube
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -41,84 +40,114 @@ common-properties:
   ignition-type: &id002
     target: CH*
     type: d/dt max
-datapoints:
+datapoints: 
 - composition: *id001
   ignition-delay:
-  - 1.7000e+02 us
+  - 170 us
   ignition-type: *id002
-  pressure:
-  - 4.8200e+01 bar
   temperature:
-  - 1.1000e+03 K
+  - 1100 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 48.2 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 2.8600e+02 us
+  - 286 us
   ignition-type: *id002
-  pressure:
-  - 5.1500e+01 bar
   temperature:
-  - 1.0670e+03 K
+  - 1067 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 51.5 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 4.3900e+02 us
+  - 439 us
   ignition-type: *id002
-  pressure:
-  - 5.0300e+01 bar
   temperature:
-  - 1.0180e+03 K
+  - 1018 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50.3 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 6.4800e+02 us
+  - 648 us
   ignition-type: *id002
-  pressure:
-  - 5.0700e+01 bar
   temperature:
-  - 9.7300e+02 K
+  - 973 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50.7 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 6.4600e+02 us
+  - 646 us
   ignition-type: *id002
-  pressure:
-  - 5.0700e+01 bar
   temperature:
-  - 9.7300e+02 K
+  - 973 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50.7 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 7.2300e+02 us
+  - 723 us
   ignition-type: *id002
-  pressure:
-  - 4.7500e+01 bar
   temperature:
-  - 9.4500e+02 K
+  - 945 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 47.5 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 6.0600e+02 us
+  - 606 us
   ignition-type: *id002
-  pressure:
-  - 5.0900e+01 bar
   temperature:
-  - 8.7700e+02 K
+  - 877 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50.9 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 6.8800e+02 us
+  - 688 us
   ignition-type: *id002
-  pressure:
-  - 4.8900e+01 bar
   temperature:
-  - 8.2500e+02 K
+  - 825 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 48.9 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 8.5500e+02 us
+  - 855 us
   ignition-type: *id002
-  pressure:
-  - 5.0800e+01 bar
   temperature:
-  - 7.7900e+02 K
+  - 779 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 50.8 bar
+  equivalence-ratio: 0.4
 - composition: *id001
   ignition-delay:
-  - 2.1560e+03 us
+  - 2156 us
   ignition-type: *id002
-  pressure:
-  - 4.7900e+01 bar
   temperature:
-  - 7.2600e+02 K
+  - 726 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 25 kelvin
+  pressure:
+  - 47.9 bar
+  equivalence-ratio: 0.4

--- a/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
+++ b/n-heptane/Herzler 2005/st_herzler_2005-4.yaml
@@ -1,8 +1,8 @@
-
-file-author:
-  name: KE Niemeyer, Oregon State University
+file-authors:
+    name: KE Niemeyer, Oregon State University
+    name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: J. Herzler

--- a/n-heptane/Horning 2002/st_horning_2002-1.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-1.yaml
@@ -1,0 +1,72 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.048
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.948
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 2.340e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.4460e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.880e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1800e+00 atm
+  temperature:
+  - 1.3810e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.370e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2300e+00 atm
+  temperature:
+  - 1.4910e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.380e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2200e+00 atm
+  temperature:
+  - 1.4380e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-1.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-1.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-1.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-1.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.4460e+03 K
+  equivalence-ratio: 0.916
 - composition: *id001
   ignition-delay:
   - 4.880e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.1800e+00 atm
   temperature:
   - 1.3810e+03 K
+  equivalence-ratio: 0.916
 - composition: *id001
   ignition-delay:
   - 1.370e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 1.2300e+00 atm
   temperature:
   - 1.4910e+03 K
+  equivalence-ratio: 0.916
 - composition: *id001
   ignition-delay:
   - 2.380e+02 us
@@ -73,3 +76,4 @@ datapoints:
   - 1.2200e+00 atm
   temperature:
   - 1.4380e+03 K
+  equivalence-ratio: 0.916

--- a/n-heptane/Horning 2002/st_horning_2002-1.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-10.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-10.yaml
@@ -1,0 +1,72 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.012
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.088
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.9
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.890e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1400e+00 atm
+  temperature:
+  - 1.4650e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.890e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2300e+00 atm
+  temperature:
+  - 1.4610e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.210e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2700e+00 atm
+  temperature:
+  - 1.4090e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.110e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2900e+00 atm
+  temperature:
+  - 1.4110e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-10.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-10.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-10.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-10.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.1400e+00 atm
   temperature:
   - 1.4650e+03 K
+  equivalence-ratio: 1.5
 - composition: *id001
   ignition-delay:
   - 1.890e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.2300e+00 atm
   temperature:
   - 1.4610e+03 K
+  equivalence-ratio: 1.5
 - composition: *id001
   ignition-delay:
   - 3.210e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 1.2700e+00 atm
   temperature:
   - 1.4090e+03 K
+  equivalence-ratio: 1.5
 - composition: *id001
   ignition-delay:
   - 3.110e+02 us
@@ -73,3 +76,4 @@ datapoints:
   - 1.2900e+00 atm
   temperature:
   - 1.4110e+03 K
+  equivalence-ratio: 1.5

--- a/n-heptane/Horning 2002/st_horning_2002-10.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-10.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-11.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-11.yaml
@@ -1,0 +1,64 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0175
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.197
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.7855
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.770e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2400e+00 atm
+  temperature:
+  - 1.3860e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.820e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1900e+00 atm
+  temperature:
+  - 1.3290e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.820e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1600e+00 atm
+  temperature:
+  - 1.3300e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-11.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-11.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-11.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-11.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-11.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-11.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.2400e+00 atm
   temperature:
   - 1.3860e+03 K
+  equivalence-ratio: 0.977
 - composition: *id001
   ignition-delay:
   - 3.820e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.1900e+00 atm
   temperature:
   - 1.3290e+03 K
+  equivalence-ratio: 0.977
 - composition: *id001
   ignition-delay:
   - 3.820e+02 us
@@ -65,3 +67,4 @@ datapoints:
   - 1.1600e+00 atm
   temperature:
   - 1.3300e+03 K
+  equivalence-ratio: 0.977

--- a/n-heptane/Horning 2002/st_horning_2002-12.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-12.yaml
@@ -1,0 +1,72 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.002
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.022
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.976
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0800e+00 atm
+  temperature:
+  - 1.5010e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.160e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1300e+00 atm
+  temperature:
+  - 1.4680e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.450e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1500e+00 atm
+  temperature:
+  - 1.4320e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0700e+00 atm
+  temperature:
+  - 1.5470e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-12.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-12.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-12.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-12.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-12.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-12.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 2.0800e+00 atm
   temperature:
   - 1.5010e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.160e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 2.1300e+00 atm
   temperature:
   - 1.4680e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.450e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 2.1500e+00 atm
   temperature:
   - 1.4320e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.000e+02 us
@@ -73,3 +76,4 @@ datapoints:
   - 2.0700e+00 atm
   temperature:
   - 1.5470e+03 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Horning 2002/st_horning_2002-13.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-13.yaml
@@ -1,0 +1,96 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.044
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.952
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 2.710e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.6800e+00 atm
+  temperature:
+  - 1.3750e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.7100e+00 atm
+  temperature:
+  - 1.4310e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.6300e+00 atm
+  temperature:
+  - 1.4000e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.380e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.6900e+00 atm
+  temperature:
+  - 1.4210e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.790e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.5700e+00 atm
+  temperature:
+  - 1.3720e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.170e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.6500e+00 atm
+  temperature:
+  - 1.4420e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.580e+02 us
+  ignition-type: *id002
+  pressure:
+  - 5.4100e+00 atm
+  temperature:
+  - 1.4190e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-13.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-13.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 5.6800e+00 atm
   temperature:
   - 1.3750e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.200e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 5.7100e+00 atm
   temperature:
   - 1.4310e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.900e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 5.6300e+00 atm
   temperature:
   - 1.4000e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.380e+02 us
@@ -73,6 +76,7 @@ datapoints:
   - 5.6900e+00 atm
   temperature:
   - 1.4210e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.790e+02 us
@@ -81,6 +85,7 @@ datapoints:
   - 5.5700e+00 atm
   temperature:
   - 1.3720e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.170e+02 us
@@ -89,6 +94,7 @@ datapoints:
   - 5.6500e+00 atm
   temperature:
   - 1.4420e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.580e+02 us
@@ -97,3 +103,4 @@ datapoints:
   - 5.4100e+00 atm
   temperature:
   - 1.4190e+03 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Horning 2002/st_horning_2002-13.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-13.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-13.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-13.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-14.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-14.yaml
@@ -1,0 +1,64 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.012
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.066
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.922
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.860e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.4230e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.050e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2100e+00 atm
+  temperature:
+  - 1.5160e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.610e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.4560e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-14.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-14.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-14.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-14.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.4230e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.050e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.2100e+00 atm
   temperature:
   - 1.5160e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.610e+02 us
@@ -65,3 +67,4 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.4560e+03 K
+  equivalence-ratio: 2.0

--- a/n-heptane/Horning 2002/st_horning_2002-14.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-14.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-2.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-2.yaml
@@ -1,0 +1,64 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0036
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.044
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.9524
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.410e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2200e+00 atm
+  temperature:
+  - 1.4920e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.250e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2500e+00 atm
+  temperature:
+  - 1.5010e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.630e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2500e+00 atm
+  temperature:
+  - 1.4760e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-2.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-2.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-2.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-2.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.2200e+00 atm
   temperature:
   - 1.4920e+03 K
+  equivalence-ratio: 0.9
 - composition: *id001
   ignition-delay:
   - 1.250e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.2500e+00 atm
   temperature:
   - 1.5010e+03 K
+  equivalence-ratio: 0.9
 - composition: *id001
   ignition-delay:
   - 1.630e+02 us
@@ -65,3 +67,4 @@ datapoints:
   - 1.2500e+00 atm
   temperature:
   - 1.4760e+03 K
+  equivalence-ratio: 0.9

--- a/n-heptane/Horning 2002/st_horning_2002-2.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-3.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-3.yaml
@@ -1,0 +1,64 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.044
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.952
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.590e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2300e+00 atm
+  temperature:
+  - 1.4860e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.080e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2700e+00 atm
+  temperature:
+  - 1.4580e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.960e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2700e+00 atm
+  temperature:
+  - 1.4280e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-3.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-3.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-3.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-3.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-3.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-3.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.2300e+00 atm
   temperature:
   - 1.4860e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.080e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.2700e+00 atm
   temperature:
   - 1.4580e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.960e+02 us
@@ -65,3 +67,4 @@ datapoints:
   - 1.2700e+00 atm
   temperature:
   - 1.4280e+03 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Horning 2002/st_horning_2002-4.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-4.yaml
@@ -1,0 +1,64 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.088
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.908
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 8.600e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.4550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.210e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.3200e+00 atm
+  temperature:
+  - 1.4130e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.860e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.3000e+00 atm
+  temperature:
+  - 1.3470e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-4.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-4.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-4.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-4.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.4550e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.210e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.3200e+00 atm
   temperature:
   - 1.4130e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.860e+02 us
@@ -65,3 +67,4 @@ datapoints:
   - 1.3000e+00 atm
   temperature:
   - 1.3470e+03 K
+  equivalence-ratio: 0.5

--- a/n-heptane/Horning 2002/st_horning_2002-4.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-4.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-5.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-5.yaml
@@ -1,0 +1,64 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.022
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.974
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.470e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2200e+00 atm
+  temperature:
+  - 1.6760e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.420e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2600e+00 atm
+  temperature:
+  - 1.5290e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2200e+00 atm
+  temperature:
+  - 1.6190e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-5.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-5.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-5.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-5.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-5.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-5.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.2200e+00 atm
   temperature:
   - 1.6760e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 4.420e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.2600e+00 atm
   temperature:
   - 1.5290e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.100e+02 us
@@ -65,3 +67,4 @@ datapoints:
   - 1.2200e+00 atm
   temperature:
   - 1.6190e+03 K
+  equivalence-ratio: 2.0

--- a/n-heptane/Horning 2002/st_horning_2002-6.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-6.yaml
@@ -1,0 +1,80 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.088
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.908
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.610e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2300e+00 atm
+  temperature:
+  - 1.3960e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.080e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2900e+00 atm
+  temperature:
+  - 1.3470e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.050e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.3400e+00 atm
+  temperature:
+  - 1.3450e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2100e+00 atm
+  temperature:
+  - 1.4320e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.230e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2200e+00 atm
+  temperature:
+  - 1.3470e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-6.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-6.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-6.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-6.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-6.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-6.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.2300e+00 atm
   temperature:
   - 1.3960e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.080e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.2900e+00 atm
   temperature:
   - 1.3470e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.050e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 1.3400e+00 atm
   temperature:
   - 1.3450e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.100e+02 us
@@ -73,6 +76,7 @@ datapoints:
   - 1.2100e+00 atm
   temperature:
   - 1.4320e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.230e+02 us
@@ -81,3 +85,4 @@ datapoints:
   - 1.2200e+00 atm
   temperature:
   - 1.3470e+03 K
+  equivalence-ratio: 0.5

--- a/n-heptane/Horning 2002/st_horning_2002-7.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-7.yaml
@@ -1,0 +1,120 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.044
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.952
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.650e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1300e+00 atm
+  temperature:
+  - 1.4550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.030e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1200e+00 atm
+  temperature:
+  - 1.3840e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.050e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1500e+00 atm
+  temperature:
+  - 1.4340e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0600e+00 atm
+  temperature:
+  - 1.5030e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.650e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1400e+00 atm
+  temperature:
+  - 1.4120e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 4.0300e+00 atm
+  temperature:
+  - 1.4760e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.630e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.0700e+00 atm
+  temperature:
+  - 1.4200e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.270e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.2200e+00 atm
+  temperature:
+  - 1.3940e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.030e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.1100e+00 atm
+  temperature:
+  - 1.4630e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.830e+02 us
+  ignition-type: *id002
+  pressure:
+  - 4.1600e+00 atm
+  temperature:
+  - 1.4130e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-7.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-7.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-7.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-7.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-7.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-7.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 2.1300e+00 atm
   temperature:
   - 1.4550e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.030e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 2.1200e+00 atm
   temperature:
   - 1.3840e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.050e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 2.1500e+00 atm
   temperature:
   - 1.4340e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.000e+02 us
@@ -73,6 +76,7 @@ datapoints:
   - 2.0600e+00 atm
   temperature:
   - 1.5030e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.650e+02 us
@@ -81,6 +85,7 @@ datapoints:
   - 2.1400e+00 atm
   temperature:
   - 1.4120e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 9.000e+01 us
@@ -89,6 +94,7 @@ datapoints:
   - 4.0300e+00 atm
   temperature:
   - 1.4760e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.630e+02 us
@@ -97,6 +103,7 @@ datapoints:
   - 4.0700e+00 atm
   temperature:
   - 1.4200e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.270e+02 us
@@ -105,6 +112,7 @@ datapoints:
   - 4.2200e+00 atm
   temperature:
   - 1.3940e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.030e+02 us
@@ -113,6 +121,7 @@ datapoints:
   - 4.1100e+00 atm
   temperature:
   - 1.4630e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.830e+02 us
@@ -121,3 +130,4 @@ datapoints:
   - 4.1600e+00 atm
   temperature:
   - 1.4130e+03 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Horning 2002/st_horning_2002-8.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-8.yaml
@@ -1,0 +1,56 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.008
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.088
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.904
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 3.850e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.3780e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.080e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1700e+00 atm
+  temperature:
+  - 1.4260e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-8.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-8.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.3780e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.080e+02 us
@@ -57,3 +58,4 @@ datapoints:
   - 1.1700e+00 atm
   temperature:
   - 1.4260e+03 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Horning 2002/st_horning_2002-8.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-8.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-8.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-8.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Horning 2002/st_horning_2002-9.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-9.yaml
@@ -1,0 +1,80 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: D. C. Horning
+  - name: D. F. Davidson
+  - name: R. K. Hanson
+  detail: Converted from ReSpecTh XML file st_horning_2002-1.xml
+  doi: 10.2514/2.5942
+  journal: Journal of Propulsion and Power
+  pages: 363-371
+  volume: 18
+  year: 2002
+experiment-type: ignition delay
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+chemked-version: 0.3.0
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.012
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.132
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.856
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.660e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.3000e+00 atm
+  temperature:
+  - 1.3350e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.150e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.4550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.630e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1900e+00 atm
+  temperature:
+  - 1.4210e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.110e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.3490e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.490e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2700e+00 atm
+  temperature:
+  - 1.4090e+03 K

--- a/n-heptane/Horning 2002/st_horning_2002-9.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-9.yaml
@@ -1,6 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D. C. Horning
@@ -17,7 +19,6 @@ apparatus:
   facility: ''
   institution: ''
   kind: shock tube
-chemked-version: 0.3.0
 common-properties:
   composition: &id001
     kind: mole fraction

--- a/n-heptane/Horning 2002/st_horning_2002-9.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-9.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,8 +18,8 @@ reference:
   year: 2002
 experiment-type: ignition delay
 apparatus:
-  facility: ''
-  institution: ''
+  facility: helium-driven high purity shock tube
+  institution: Stanford University
   kind: shock tube
 common-properties:
   composition: &id001
@@ -49,6 +49,7 @@ datapoints:
   - 1.3000e+00 atm
   temperature:
   - 1.3350e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.150e+02 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.4550e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.630e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 1.1900e+00 atm
   temperature:
   - 1.4210e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.110e+02 us
@@ -73,6 +76,7 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.3490e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.490e+02 us
@@ -81,3 +85,4 @@ datapoints:
   - 1.2700e+00 atm
   temperature:
   - 1.4090e+03 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Horning 2002/st_horning_2002-9.yaml
+++ b/n-heptane/Horning 2002/st_horning_2002-9.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Karwat 2013/rcm_karwat_2013-1.yaml
+++ b/n-heptane/Karwat 2013/rcm_karwat_2013-1.yaml
@@ -1,0 +1,59 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+  - name: Darshan M.A. Karwat
+  - name: Scott W. Wagnon
+  - name: Margaret S. Wooldridge
+  - name: Charles K. Westbrook
+  detail: Converted from ReSpecTh XML file rcm_karwat_2013-1.xml
+  doi: 10.1016/j.combustflame.2013.06.029
+  journal: Combustion and Flame
+  pages: 2693-2706
+  volume: 160
+  year: 2013
+experiment-type: ignition delay
+apparatus:
+  facility: UM RCF
+  institution: University of Michigan
+  kind: rapid compression machine
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0134
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1489
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.2211
+      species-name: N2
+    - InChI: 1S/CO2/c2-1-3
+      amount:
+      - 0.6166
+      species-name: CO2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 7.13 ms
+  ignition-type: *id002
+  pressure:
+  - 9.33 atm
+  temperature:
+  - 707. K
+  equivalence-ratio: 1.0
+
+

--- a/n-heptane/Karwat 2013/rcm_karwat_2013-2.yaml
+++ b/n-heptane/Karwat 2013/rcm_karwat_2013-2.yaml
@@ -1,0 +1,53 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+  - name: Darshan M.A. Karwat
+  - name: Scott W. Wagnon
+  - name: Margaret S. Wooldridge
+  - name: Charles K. Westbrook
+  detail: Converted from ReSpecTh XML file rcm_karwat_2013-1.xml
+  doi: 10.1016/j.combustflame.2013.06.029
+  journal: Combustion and Flame
+  pages: 2693-2706
+  volume: 160
+  year: 2013
+experiment-type: ignition delay
+apparatus:
+  facility: UM RCF
+  institution: University of Michigan
+  kind: rapid compression machine
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.013444
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1489
+      species-name: O2
+    - InChI: 1S/CO2/c2-1-3
+      amount:
+      - 0.837656
+      species-name: CO2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 30.06 ms
+  ignition-type: *id002
+  pressure:
+  - 9.53 atm
+  temperature:
+  - 660. K
+  equivalence-ratio: 1.0

--- a/n-heptane/Karwat 2013/rcm_karwat_2013-3.yaml
+++ b/n-heptane/Karwat 2013/rcm_karwat_2013-3.yaml
@@ -1,0 +1,57 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+  - name: Darshan M.A. Karwat
+  - name: Scott W. Wagnon
+  - name: Margaret S. Wooldridge
+  - name: Charles K. Westbrook
+  detail: Converted from ReSpecTh XML file rcm_karwat_2013-1.xml
+  doi: 10.1016/j.combustflame.2013.06.029
+  journal: Combustion and Flame
+  pages: 2693-2706
+  volume: 160
+  year: 2013
+experiment-type: ignition delay
+apparatus:
+  facility: UM RCF
+  institution: University of Michigan
+  kind: rapid compression machine
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.013433
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1491
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.1337
+      species-name: N2
+    - InChI: 1S/CO2/c2-1-3
+      amount:
+      - 0.703767
+      species-name: CO2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 11.65 ms
+  ignition-type: *id002
+  pressure:
+  - 9.44 atm
+  temperature:
+  - 686. K
+  equivalence-ratio: 1.0

--- a/n-heptane/Shen 2009/st_shen_2009-1.yaml
+++ b/n-heptane/Shen 2009/st_shen_2009-1.yaml
@@ -1,0 +1,248 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Hsi-Ping S. Shen
+    - name: J. Steinberg
+    - name: J. Vanderover
+    - name: MA Oehlschlaeger
+  journal: Energy & Fuels
+  year: 2009
+  volume: 23
+  pages: 2482-2489
+  doi: 10.1021/ef8011036
+  detail: Converted from ReSpecTh XML file st_shen_2009-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Rensselaer Polytechnic Institute
+  facility: high-pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004752
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2091
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.786148
+      species-name: N2
+  ignition-type: &id002
+    target: OH*
+    type: max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1687 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1064 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 13.5 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1111 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1078 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.6 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1378 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1092 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 13 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 868 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1116 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.2 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 719 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1133 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 13 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 373 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1204 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 10.5 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 339 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1206 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 228 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1248 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 11.9 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 108 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1309 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 96 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1317 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.1 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 88 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1336 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.8 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 42 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1396 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 11.8 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+    - 0.02 1/ms
+  equivalence-ratio: 0.25

--- a/n-heptane/Shen 2009/st_shen_2009-2.yaml
+++ b/n-heptane/Shen 2009/st_shen_2009-2.yaml
@@ -1,0 +1,299 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Hsi-Ping S. Shen
+    - name: J. Steinberg
+    - name: J. Vanderover
+    - name: MA Oehlschlaeger
+  journal: Energy & Fuels
+  year: 2009
+  volume: 23
+  pages: 2482-2489
+  doi: 10.1021/ef8011036
+  detail: Converted from ReSpecTh XML file st_shen_2009-2.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Rensselaer Polytechnic Institute
+  facility: high-pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004752
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2091
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.786148
+      species-name: N2
+  ignition-type: &id002
+    target: OH*
+    type: max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1500 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 786 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 49.9 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1443 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 791 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 38 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1344 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 830 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 39.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1402 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 831 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 48.3 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1289 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 836 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 52 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1503 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 856 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 39.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1374 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 872 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 50.9 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1498 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 920 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 43.1 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1566 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 948 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 42.3 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 1518 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 987 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 42 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 626 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1055 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 43.9 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 386 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1099 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 43.4 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 229 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1147 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 47.4 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 193 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1178 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 42.5 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25
+- composition: *id001
+  ignition-delay:
+  - 93 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1230 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 39.6 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.25

--- a/n-heptane/Shen 2009/st_shen_2009-3.yaml
+++ b/n-heptane/Shen 2009/st_shen_2009-3.yaml
@@ -1,0 +1,129 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Hsi-Ping S. Shen
+    - name: J. Steinberg
+    - name: J. Vanderover
+    - name: MA Oehlschlaeger
+  journal: Energy & Fuels
+  year: 2009
+  volume: 23
+  pages: 2482-2489
+  doi: 10.1021/ef8011036
+  detail: Converted from ReSpecTh XML file st_shen_2009-3.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Rensselaer Polytechnic Institute
+  facility: high-pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.009459
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2081
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.782441
+      species-name: N2
+  ignition-type: &id002
+    target: OH*
+    type: max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1028 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1063 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 14.9 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 1027 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1063 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 14.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 692 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1101 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 243 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1168 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.8 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 130 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1224 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 11.8 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5

--- a/n-heptane/Shen 2009/st_shen_2009-4.yaml
+++ b/n-heptane/Shen 2009/st_shen_2009-4.yaml
@@ -1,0 +1,163 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Hsi-Ping S. Shen
+    - name: J. Steinberg
+    - name: J. Vanderover
+    - name: MA Oehlschlaeger
+  journal: Energy & Fuels
+  year: 2009
+  volume: 23
+  pages: 2482-2489
+  doi: 10.1021/ef8011036
+  detail: Converted from ReSpecTh XML file st_shen_2009-4.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Rensselaer Polytechnic Institute
+  facility: high-pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.009459
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2081
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.782441
+      species-name: N2
+  ignition-type: &id002
+    target: OH*
+    type: max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 669 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 829 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 38.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 758 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 873 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 40.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 824 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 944 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 44.3 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 611 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1014 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 47.3 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 258 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1082 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 43.5 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 210 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1110 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 51.6 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 90 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1161 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 46.2 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 0.5

--- a/n-heptane/Shen 2009/st_shen_2009-5.yaml
+++ b/n-heptane/Shen 2009/st_shen_2009-5.yaml
@@ -1,0 +1,163 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Hsi-Ping S. Shen
+    - name: J. Steinberg
+    - name: J. Vanderover
+    - name: MA Oehlschlaeger
+  journal: Energy & Fuels
+  year: 2009
+  volume: 23
+  pages: 2482-2489
+  doi: 10.1021/ef8011036
+  detail: Converted from ReSpecTh XML file st_shen_2009-5.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Rensselaer Polytechnic Institute
+  facility: high-pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2062
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77506
+      species-name: N2
+  ignition-type: &id002
+    target: OH*
+    type: max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 2672 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 809 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 10.8 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3048 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 826 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 10.6 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 2384 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 972 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 11.8 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1101 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1058 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 11.9 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 653 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1096 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 11.9 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 678 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1098 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.6 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 189 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1196 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 12.3 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1

--- a/n-heptane/Shen 2009/st_shen_2009-6.yaml
+++ b/n-heptane/Shen 2009/st_shen_2009-6.yaml
@@ -1,0 +1,265 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Hsi-Ping S. Shen
+    - name: J. Steinberg
+    - name: J. Vanderover
+    - name: MA Oehlschlaeger
+  journal: Energy & Fuels
+  year: 2009
+  volume: 23
+  pages: 2482-2489
+  doi: 10.1021/ef8011036
+  detail: Converted from ReSpecTh XML file st_shen_2009-6.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Rensselaer Polytechnic Institute
+  facility: high-pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.01874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2062
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.77506
+      species-name: N2
+  ignition-type: &id002
+    target: OH*
+    type: max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 295 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 788 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 49.2 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 379 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 797 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 53.6 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 319 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 799 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 47.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 284 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 834 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 49.4 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 295 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 862 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 49.7 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 381 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 899 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 46.4 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 491 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 967 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 52.5 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 447 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 991 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 50.3 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 336 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 996 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 48.1 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 344 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1003 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 43.5 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 282 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1022 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 45 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 297 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1029 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 47.5 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 259 us
+  - uncertainty-type: relative
+    uncertainty: 0.2
+  ignition-type: *id002
+  temperature:
+  - 1050 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.015
+  pressure:
+  - 48.4 atm
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.02 1/ms
+  equivalence-ratio: 1

--- a/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
@@ -1,0 +1,368 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-1.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+experiment-type: ignition delay
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.088
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.908
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.0900e+00 atm
+  temperature:
+  - 1.5910e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.7000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.5240e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0300e+00 atm
+  temperature:
+  - 1.4560e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.4110e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.8400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.8000e-01 atm
+  temperature:
+  - 1.3770e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.8000e-01 atm
+  temperature:
+  - 1.3770e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0200e+00 atm
+  temperature:
+  - 1.3880e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0700e+00 atm
+  temperature:
+  - 1.4340e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.8700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.3930e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.1700e+00 atm
+  temperature:
+  - 1.4700e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1100e+00 atm
+  temperature:
+  - 1.4160e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.3640e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.4410e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.7000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.9000e-01 atm
+  temperature:
+  - 1.3220e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.7000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.4400e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.5500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.3260e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.6900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.4050e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1200e+00 atm
+  temperature:
+  - 1.4130e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.7300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.8000e-01 atm
+  temperature:
+  - 1.3070e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.6100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.4000e-01 atm
+  temperature:
+  - 1.2700e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.3590e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.2900e+00 atm
+  temperature:
+  - 1.5380e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1800e+00 atm
+  temperature:
+  - 1.4540e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.3860e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.0600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.9000e-01 atm
+  temperature:
+  - 1.2980e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.3800e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.4430e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.5800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.3320e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1700e+00 atm
+  temperature:
+  - 1.4210e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.4700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.3290e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.0500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.3360e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.9300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1400e+00 atm
+  temperature:
+  - 1.4020e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.8700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1600e+00 atm
+  temperature:
+  - 1.4060e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1600e+00 atm
+  temperature:
+  - 1.4050e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.3800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1400e+00 atm
+  temperature:
+  - 1.3890e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.1400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1200e+00 atm
+  temperature:
+  - 1.3690e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.9100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0100e+00 atm
+  temperature:
+  - 1.2910e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.3510e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.8400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1200e+00 atm
+  temperature:
+  - 1.3610e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.3800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1600e+00 atm
+  temperature:
+  - 1.3850e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1800e+00 atm
+  temperature:
+  - 1.4020e+03 K

--- a/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: John M. Smith

--- a/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-1.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -17,8 +17,8 @@ reference:
   volume: 37
   year: 2005
 apparatus:
-  facility: ''
-  institution: ''
+  facility: stainless steel shock tube
+  institution: NUI Galway
   kind: shock tube
 experiment-type: ignition delay
 common-properties:
@@ -49,6 +49,7 @@ datapoints:
   - 1.0900e+00 atm
   temperature:
   - 1.5910e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 6.7000e+01 us
@@ -57,6 +58,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.5240e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.1600e+02 us
@@ -65,6 +67,7 @@ datapoints:
   - 1.0300e+00 atm
   temperature:
   - 1.4560e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.7500e+02 us
@@ -73,6 +76,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.4110e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.8400e+02 us
@@ -81,6 +85,7 @@ datapoints:
   - 9.8000e-01 atm
   temperature:
   - 1.3770e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.0000e+02 us
@@ -89,6 +94,7 @@ datapoints:
   - 9.8000e-01 atm
   temperature:
   - 1.3770e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.2800e+02 us
@@ -97,6 +103,7 @@ datapoints:
   - 1.0200e+00 atm
   temperature:
   - 1.3880e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.3300e+02 us
@@ -105,6 +112,7 @@ datapoints:
   - 1.0700e+00 atm
   temperature:
   - 1.4340e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.8700e+02 us
@@ -113,6 +121,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.3930e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 9.2000e+01 us
@@ -121,6 +130,7 @@ datapoints:
   - 1.1700e+00 atm
   temperature:
   - 1.4700e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.2200e+02 us
@@ -129,6 +139,7 @@ datapoints:
   - 1.1100e+00 atm
   temperature:
   - 1.4160e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.7100e+02 us
@@ -137,6 +148,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.3640e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.1400e+02 us
@@ -145,6 +157,7 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.4410e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 4.7000e+02 us
@@ -153,6 +166,7 @@ datapoints:
   - 9.9000e-01 atm
   temperature:
   - 1.3220e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 9.7000e+01 us
@@ -161,6 +175,7 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.4400e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.5500e+02 us
@@ -169,6 +184,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.3260e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.6900e+02 us
@@ -177,6 +193,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.4050e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.3200e+02 us
@@ -185,6 +202,7 @@ datapoints:
   - 1.1200e+00 atm
   temperature:
   - 1.4130e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 4.7300e+02 us
@@ -193,6 +211,7 @@ datapoints:
   - 9.8000e-01 atm
   temperature:
   - 1.3070e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 6.6100e+02 us
@@ -201,6 +220,7 @@ datapoints:
   - 9.4000e-01 atm
   temperature:
   - 1.2700e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.1500e+02 us
@@ -209,6 +229,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.3590e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 5.5000e+01 us
@@ -217,6 +238,7 @@ datapoints:
   - 1.2900e+00 atm
   temperature:
   - 1.5380e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.1700e+02 us
@@ -225,6 +247,7 @@ datapoints:
   - 1.1800e+00 atm
   temperature:
   - 1.4540e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.7200e+02 us
@@ -233,6 +256,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.3860e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 6.0600e+02 us
@@ -241,6 +265,7 @@ datapoints:
   - 9.9000e-01 atm
   temperature:
   - 1.2980e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.2100e+02 us
@@ -249,6 +274,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.3800e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.2300e+02 us
@@ -257,6 +283,7 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.4430e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.5800e+02 us
@@ -265,6 +292,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.3320e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.4200e+02 us
@@ -273,6 +301,7 @@ datapoints:
   - 1.1700e+00 atm
   temperature:
   - 1.4210e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 4.4700e+02 us
@@ -281,6 +310,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.3290e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 5.0500e+02 us
@@ -289,6 +319,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.3360e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.9300e+02 us
@@ -297,6 +328,7 @@ datapoints:
   - 1.1400e+00 atm
   temperature:
   - 1.4020e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 1.8700e+02 us
@@ -305,6 +337,7 @@ datapoints:
   - 1.1600e+00 atm
   temperature:
   - 1.4060e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.1100e+02 us
@@ -313,6 +346,7 @@ datapoints:
   - 1.1600e+00 atm
   temperature:
   - 1.4050e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.3800e+02 us
@@ -321,6 +355,7 @@ datapoints:
   - 1.1400e+00 atm
   temperature:
   - 1.3890e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.1400e+02 us
@@ -329,6 +364,7 @@ datapoints:
   - 1.1200e+00 atm
   temperature:
   - 1.3690e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 6.9100e+02 us
@@ -337,6 +373,7 @@ datapoints:
   - 1.0100e+00 atm
   temperature:
   - 1.2910e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 3.3100e+02 us
@@ -345,6 +382,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.3510e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.8400e+02 us
@@ -353,6 +391,7 @@ datapoints:
   - 1.1200e+00 atm
   temperature:
   - 1.3610e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.3800e+02 us
@@ -361,6 +400,7 @@ datapoints:
   - 1.1600e+00 atm
   temperature:
   - 1.3850e+03 K
+  equivalence-ratio: 0.5
 - composition: *id001
   ignition-delay:
   - 2.0300e+02 us
@@ -369,3 +409,4 @@ datapoints:
   - 1.1800e+00 atm
   temperature:
   - 1.4020e+03 K
+  equivalence-ratio: 0.5

--- a/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
@@ -1,0 +1,350 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-1.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0149
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.16
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.8251
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 2.7000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.8300e+00 atm
+  temperature:
+  - 1.5840e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.1000e+00 atm
+  temperature:
+  - 1.7180e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.8000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.0100e+00 atm
+  temperature:
+  - 1.6300e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9000e+00 atm
+  temperature:
+  - 1.5760e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.0000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9400e+00 atm
+  temperature:
+  - 1.5600e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.8300e+00 atm
+  temperature:
+  - 1.4840e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.8900e+00 atm
+  temperature:
+  - 1.5070e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.0000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9900e+00 atm
+  temperature:
+  - 1.5550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.3000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9400e+00 atm
+  temperature:
+  - 1.5090e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.3000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9600e+00 atm
+  temperature:
+  - 1.5130e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.0000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9000e+00 atm
+  temperature:
+  - 1.4820e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.0200e+00 atm
+  temperature:
+  - 1.5240e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.8700e+00 atm
+  temperature:
+  - 1.4410e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9700e+00 atm
+  temperature:
+  - 1.4700e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.1000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9300e+00 atm
+  temperature:
+  - 1.4420e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8500e+00 atm
+  temperature:
+  - 1.3810e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.8300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0000e+00 atm
+  temperature:
+  - 1.3550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0400e+00 atm
+  temperature:
+  - 1.3700e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0500e+00 atm
+  temperature:
+  - 1.3750e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.8000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.9400e+00 atm
+  temperature:
+  - 1.3270e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.8200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0000e+00 atm
+  temperature:
+  - 1.3500e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.2100e+00 atm
+  temperature:
+  - 1.3350e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.2400e+00 atm
+  temperature:
+  - 1.3370e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.8500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8800e+00 atm
+  temperature:
+  - 1.2090e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.7400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1200e+00 atm
+  temperature:
+  - 1.2660e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.2700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.2100e+00 atm
+  temperature:
+  - 1.2910e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.5700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1700e+00 atm
+  temperature:
+  - 1.2580e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4130e+03 us
+  ignition-type: *id002
+  pressure:
+  - 1.9000e+00 atm
+  temperature:
+  - 1.1680e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.6400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.2300e+00 atm
+  temperature:
+  - 1.2730e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2580e+03 us
+  ignition-type: *id002
+  pressure:
+  - 1.9200e+00 atm
+  temperature:
+  - 1.1750e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1190e+03 us
+  ignition-type: *id002
+  pressure:
+  - 1.9600e+00 atm
+  temperature:
+  - 1.1860e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.6000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.2200e+00 atm
+  temperature:
+  - 1.2680e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.0770e+03 us
+  ignition-type: *id002
+  pressure:
+  - 2.0200e+00 atm
+  temperature:
+  - 1.2050e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.7000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1800e+00 atm
+  temperature:
+  - 1.2570e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.8700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1600e+00 atm
+  temperature:
+  - 1.2490e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.6700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1900e+00 atm
+  temperature:
+  - 1.2570e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.4300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1600e+00 atm
+  temperature:
+  - 1.2420e+03 K
+experiment-type: ignition delay
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-2.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005

--- a/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -17,9 +17,10 @@ reference:
   volume: 37
   year: 2005
 apparatus:
-  facility: ''
-  institution: ''
+  facility: stainless steel shock tube
+  institution: NUI Galway
   kind: shock tube
+experiment-type: ignition delay
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +49,7 @@ datapoints:
   - 1.8300e+00 atm
   temperature:
   - 1.5840e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.4000e+01 us
@@ -56,6 +58,7 @@ datapoints:
   - 2.1000e+00 atm
   temperature:
   - 1.7180e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 2.8000e+01 us
@@ -64,6 +67,7 @@ datapoints:
   - 2.0100e+00 atm
   temperature:
   - 1.6300e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 3.2000e+01 us
@@ -72,6 +76,7 @@ datapoints:
   - 1.9000e+00 atm
   temperature:
   - 1.5760e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 4.0000e+01 us
@@ -80,6 +85,7 @@ datapoints:
   - 1.9400e+00 atm
   temperature:
   - 1.5600e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 5.2000e+01 us
@@ -88,6 +94,7 @@ datapoints:
   - 1.8300e+00 atm
   temperature:
   - 1.4840e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 5.2000e+01 us
@@ -96,6 +103,7 @@ datapoints:
   - 1.8900e+00 atm
   temperature:
   - 1.5070e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 4.0000e+01 us
@@ -104,6 +112,7 @@ datapoints:
   - 1.9900e+00 atm
   temperature:
   - 1.5550e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 5.3000e+01 us
@@ -112,6 +121,7 @@ datapoints:
   - 1.9400e+00 atm
   temperature:
   - 1.5090e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 5.3000e+01 us
@@ -120,6 +130,7 @@ datapoints:
   - 1.9600e+00 atm
   temperature:
   - 1.5130e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 6.0000e+01 us
@@ -128,6 +139,7 @@ datapoints:
   - 1.9000e+00 atm
   temperature:
   - 1.4820e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 4.2000e+01 us
@@ -136,6 +148,7 @@ datapoints:
   - 2.0200e+00 atm
   temperature:
   - 1.5240e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 9.4000e+01 us
@@ -144,6 +157,7 @@ datapoints:
   - 1.8700e+00 atm
   temperature:
   - 1.4410e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 6.5000e+01 us
@@ -152,6 +166,7 @@ datapoints:
   - 1.9700e+00 atm
   temperature:
   - 1.4700e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 8.1000e+01 us
@@ -160,6 +175,7 @@ datapoints:
   - 1.9300e+00 atm
   temperature:
   - 1.4420e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.2400e+02 us
@@ -168,6 +184,7 @@ datapoints:
   - 1.8500e+00 atm
   temperature:
   - 1.3810e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.8300e+02 us
@@ -176,6 +193,7 @@ datapoints:
   - 2.0000e+00 atm
   temperature:
   - 1.3550e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.4400e+02 us
@@ -184,6 +202,7 @@ datapoints:
   - 2.0400e+00 atm
   temperature:
   - 1.3700e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.3400e+02 us
@@ -192,6 +211,7 @@ datapoints:
   - 2.0500e+00 atm
   temperature:
   - 1.3750e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 2.8000e+02 us
@@ -200,6 +220,7 @@ datapoints:
   - 1.9400e+00 atm
   temperature:
   - 1.3270e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.8200e+02 us
@@ -208,6 +229,7 @@ datapoints:
   - 2.0000e+00 atm
   temperature:
   - 1.3500e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 2.1100e+02 us
@@ -216,6 +238,7 @@ datapoints:
   - 2.2100e+00 atm
   temperature:
   - 1.3350e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 2.1200e+02 us
@@ -224,6 +247,7 @@ datapoints:
   - 2.2400e+00 atm
   temperature:
   - 1.3370e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 8.8500e+02 us
@@ -232,6 +256,7 @@ datapoints:
   - 1.8800e+00 atm
   temperature:
   - 1.2090e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 3.7400e+02 us
@@ -240,6 +265,7 @@ datapoints:
   - 2.1200e+00 atm
   temperature:
   - 1.2660e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 3.2700e+02 us
@@ -248,6 +274,7 @@ datapoints:
   - 2.2100e+00 atm
   temperature:
   - 1.2910e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 4.5700e+02 us
@@ -256,6 +283,7 @@ datapoints:
   - 2.1700e+00 atm
   temperature:
   - 1.2580e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.4130e+03 us
@@ -264,6 +292,7 @@ datapoints:
   - 1.9000e+00 atm
   temperature:
   - 1.1680e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 3.6400e+02 us
@@ -272,6 +301,7 @@ datapoints:
   - 2.2300e+00 atm
   temperature:
   - 1.2730e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.2580e+03 us
@@ -280,6 +310,7 @@ datapoints:
   - 1.9200e+00 atm
   temperature:
   - 1.1750e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.1190e+03 us
@@ -288,6 +319,7 @@ datapoints:
   - 1.9600e+00 atm
   temperature:
   - 1.1860e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 3.6000e+02 us
@@ -296,6 +328,7 @@ datapoints:
   - 2.2200e+00 atm
   temperature:
   - 1.2680e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 1.0770e+03 us
@@ -304,6 +337,7 @@ datapoints:
   - 2.0200e+00 atm
   temperature:
   - 1.2050e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 4.7000e+02 us
@@ -312,6 +346,7 @@ datapoints:
   - 2.1800e+00 atm
   temperature:
   - 1.2570e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 5.8700e+02 us
@@ -320,6 +355,7 @@ datapoints:
   - 2.1600e+00 atm
   temperature:
   - 1.2490e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 4.6700e+02 us
@@ -328,6 +364,7 @@ datapoints:
   - 2.1900e+00 atm
   temperature:
   - 1.2570e+03 K
+  equivalence-ratio: 1.024
 - composition: *id001
   ignition-delay:
   - 6.4300e+02 us
@@ -336,18 +373,4 @@ datapoints:
   - 2.1600e+00 atm
   temperature:
   - 1.2420e+03 K
-experiment-type: ignition delay
-file-author:
-  name: KE Niemeyer, Oregon State University
-file-version: 0
-reference:
-  authors:
-  - name: John M. Smith
-  - name: John M. Simmie
-  - name: Henry J. Curran
-  detail: Converted from ReSpecTh XML file st_smith_2005-2.xml
-  doi: 10.1002/kin.20120
-  journal: International Journal of Chemical Kinetics
-  pages: 728-736
-  volume: 37
-  year: 2005
+  equivalence-ratio: 1.024

--- a/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-2.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: John M. Smith

--- a/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
@@ -1,0 +1,534 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-1.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.044
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.952
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.1300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.4000e-01 atm
+  temperature:
+  - 1.5560e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 8.8000e-01 atm
+  temperature:
+  - 1.4500e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.5680e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.8000e-01 atm
+  temperature:
+  - 1.5520e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.5550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.4000e-01 atm
+  temperature:
+  - 1.4820e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.8400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.7000e-01 atm
+  temperature:
+  - 1.4840e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.5910e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.5240e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.5220e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.1500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.5780e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.5550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.5600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0700e+00 atm
+  temperature:
+  - 1.5360e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.6700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.6000e-01 atm
+  temperature:
+  - 1.4400e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0800e+00 atm
+  temperature:
+  - 1.5530e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.7100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.4000e-01 atm
+  temperature:
+  - 1.4180e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.5280e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.4790e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.1600e+00 atm
+  temperature:
+  - 1.6170e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.8500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.7000e-01 atm
+  temperature:
+  - 1.4500e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.7000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.1900e+00 atm
+  temperature:
+  - 1.6340e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.5250e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0900e+00 atm
+  temperature:
+  - 1.5390e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.6000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.8000e-01 atm
+  temperature:
+  - 1.4190e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.7500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.8000e-01 atm
+  temperature:
+  - 1.4280e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.4800e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1200e+00 atm
+  temperature:
+  - 1.5490e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.5900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.4730e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.5700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.5000e-01 atm
+  temperature:
+  - 1.3800e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.0300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.9000e-01 atm
+  temperature:
+  - 1.4010e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.4550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.6000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.4980e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.4550e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.0400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.4030e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.5600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.5000e-01 atm
+  temperature:
+  - 1.3690e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.6200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0300e+00 atm
+  temperature:
+  - 1.4310e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.2000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.4530e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0900e+00 atm
+  temperature:
+  - 1.4830e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0700e+00 atm
+  temperature:
+  - 1.4680e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.0200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.4540e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.1600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.4450e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.4570e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1400e+00 atm
+  temperature:
+  - 1.5170e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.4800e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2900e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0900e+00 atm
+  temperature:
+  - 1.4720e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1700e+00 atm
+  temperature:
+  - 1.5380e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.6800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1400e+00 atm
+  temperature:
+  - 1.5110e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.9300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0100e+00 atm
+  temperature:
+  - 1.3980e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.5800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1600e+00 atm
+  temperature:
+  - 1.5130e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.2800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.4180e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.4100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.4160e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.2700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.4270e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.2600e+00 atm
+  temperature:
+  - 1.5860e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.5600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.7000e-01 atm
+  temperature:
+  - 1.3460e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1400e+00 atm
+  temperature:
+  - 1.4760e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1900e+00 atm
+  temperature:
+  - 1.5090e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.4200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0700e+00 atm
+  temperature:
+  - 1.3970e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1800e+00 atm
+  temperature:
+  - 1.4870e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.7700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0800e+00 atm
+  temperature:
+  - 1.4100e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.3600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.4600e+03 K
+experiment-type: ignition delay
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-3.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005

--- a/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -17,9 +17,10 @@ reference:
   volume: 37
   year: 2005
 apparatus:
-  facility: ''
-  institution: ''
+  facility: stainless steal shock tube
+  institution: NUI Galway
   kind: shock tube
+experiment-type: ignition delay
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +49,7 @@ datapoints:
   - 9.4000e-01 atm
   temperature:
   - 1.5560e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.7100e+02 us
@@ -56,6 +58,7 @@ datapoints:
   - 8.8000e-01 atm
   temperature:
   - 1.4500e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.2300e+02 us
@@ -64,6 +67,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.5680e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.4300e+02 us
@@ -72,6 +76,7 @@ datapoints:
   - 9.8000e-01 atm
   temperature:
   - 1.5520e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.3200e+02 us
@@ -80,6 +85,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.5550e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.2100e+02 us
@@ -88,6 +94,7 @@ datapoints:
   - 9.4000e-01 atm
   temperature:
   - 1.4820e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.8400e+02 us
@@ -96,6 +103,7 @@ datapoints:
   - 9.7000e-01 atm
   temperature:
   - 1.4840e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 9.2000e+01 us
@@ -104,6 +112,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.5910e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.7800e+02 us
@@ -112,6 +121,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.5240e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.3300e+02 us
@@ -120,6 +130,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.5220e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.1500e+02 us
@@ -128,6 +139,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.5780e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.4000e+02 us
@@ -136,6 +148,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.5550e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.5600e+02 us
@@ -144,6 +157,7 @@ datapoints:
   - 1.0700e+00 atm
   temperature:
   - 1.5360e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.6700e+02 us
@@ -152,6 +166,7 @@ datapoints:
   - 9.6000e-01 atm
   temperature:
   - 1.4400e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.2600e+02 us
@@ -160,6 +175,7 @@ datapoints:
   - 1.0800e+00 atm
   temperature:
   - 1.5530e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.7100e+02 us
@@ -168,6 +184,7 @@ datapoints:
   - 9.4000e-01 atm
   temperature:
   - 1.4180e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.4200e+02 us
@@ -176,6 +193,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.5280e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.0400e+02 us
@@ -184,6 +202,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.4790e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 7.4000e+01 us
@@ -192,6 +211,7 @@ datapoints:
   - 1.1600e+00 atm
   temperature:
   - 1.6170e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.8500e+02 us
@@ -200,6 +220,7 @@ datapoints:
   - 9.7000e-01 atm
   temperature:
   - 1.4500e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.7000e+01 us
@@ -208,6 +229,7 @@ datapoints:
   - 1.1900e+00 atm
   temperature:
   - 1.6340e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.4900e+02 us
@@ -216,6 +238,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.5250e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.2100e+02 us
@@ -224,6 +247,7 @@ datapoints:
   - 1.0900e+00 atm
   temperature:
   - 1.5390e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.6000e+02 us
@@ -232,6 +256,7 @@ datapoints:
   - 9.8000e-01 atm
   temperature:
   - 1.4190e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.7500e+02 us
@@ -240,6 +265,7 @@ datapoints:
   - 9.8000e-01 atm
   temperature:
   - 1.4280e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.1700e+02 us
@@ -248,6 +274,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.4800e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.3300e+02 us
@@ -256,6 +283,7 @@ datapoints:
   - 1.1200e+00 atm
   temperature:
   - 1.5490e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.5900e+02 us
@@ -264,6 +292,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.4730e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.5700e+02 us
@@ -272,6 +301,7 @@ datapoints:
   - 9.5000e-01 atm
   temperature:
   - 1.3800e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.0300e+02 us
@@ -280,6 +310,7 @@ datapoints:
   - 9.9000e-01 atm
   temperature:
   - 1.4010e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.7200e+02 us
@@ -288,6 +319,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.4550e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.6000e+02 us
@@ -296,6 +328,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.4980e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.0000e+02 us
@@ -304,6 +337,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.4550e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.0400e+02 us
@@ -312,6 +346,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.4030e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.5600e+02 us
@@ -320,6 +355,7 @@ datapoints:
   - 9.5000e-01 atm
   temperature:
   - 1.3690e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.6200e+02 us
@@ -328,6 +364,7 @@ datapoints:
   - 1.0300e+00 atm
   temperature:
   - 1.4310e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.2000e+02 us
@@ -336,6 +373,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.4530e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.0300e+02 us
@@ -344,6 +382,7 @@ datapoints:
   - 1.0900e+00 atm
   temperature:
   - 1.4830e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.7000e+02 us
@@ -352,6 +391,7 @@ datapoints:
   - 1.0700e+00 atm
   temperature:
   - 1.4680e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.0200e+02 us
@@ -360,6 +400,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.4540e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.1600e+02 us
@@ -368,6 +409,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.4450e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.0900e+02 us
@@ -376,6 +418,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.4570e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.3100e+02 us
@@ -384,6 +427,7 @@ datapoints:
   - 1.1400e+00 atm
   temperature:
   - 1.5170e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.2000e+02 us
@@ -392,6 +436,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.4800e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.2900e+02 us
@@ -400,6 +445,7 @@ datapoints:
   - 1.0900e+00 atm
   temperature:
   - 1.4720e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.3200e+02 us
@@ -408,6 +454,7 @@ datapoints:
   - 1.1700e+00 atm
   temperature:
   - 1.5380e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.6800e+02 us
@@ -416,6 +463,7 @@ datapoints:
   - 1.1400e+00 atm
   temperature:
   - 1.5110e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.9300e+02 us
@@ -424,6 +472,7 @@ datapoints:
   - 1.0100e+00 atm
   temperature:
   - 1.3980e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.5800e+02 us
@@ -432,6 +481,7 @@ datapoints:
   - 1.1600e+00 atm
   temperature:
   - 1.5130e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.2800e+02 us
@@ -440,6 +490,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.4180e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.4100e+02 us
@@ -448,6 +499,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.4160e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.2700e+02 us
@@ -456,6 +508,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.4270e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 9.5000e+01 us
@@ -464,6 +517,7 @@ datapoints:
   - 1.2600e+00 atm
   temperature:
   - 1.5860e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 9.5600e+02 us
@@ -472,6 +526,7 @@ datapoints:
   - 9.7000e-01 atm
   temperature:
   - 1.3460e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.2800e+02 us
@@ -480,6 +535,7 @@ datapoints:
   - 1.1400e+00 atm
   temperature:
   - 1.4760e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.7700e+02 us
@@ -488,6 +544,7 @@ datapoints:
   - 1.1900e+00 atm
   temperature:
   - 1.5090e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.4200e+02 us
@@ -496,6 +553,7 @@ datapoints:
   - 1.0700e+00 atm
   temperature:
   - 1.3970e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.0800e+02 us
@@ -504,6 +562,7 @@ datapoints:
   - 1.1800e+00 atm
   temperature:
   - 1.4870e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.7700e+02 us
@@ -512,6 +571,7 @@ datapoints:
   - 1.0800e+00 atm
   temperature:
   - 1.4100e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.3600e+02 us
@@ -520,18 +580,5 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.4600e+03 K
-experiment-type: ignition delay
-file-author:
-  name: KE Niemeyer, Oregon State University
-file-version: 0
-reference:
-  authors:
-  - name: John M. Smith
-  - name: John M. Simmie
-  - name: Henry J. Curran
-  detail: Converted from ReSpecTh XML file st_smith_2005-3.xml
-  doi: 10.1002/kin.20120
-  journal: International Journal of Chemical Kinetics
-  pages: 728-736
-  volume: 37
-  year: 2005
+  equivalence-ratio: 1.0
+

--- a/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-3.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: John M. Smith

--- a/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
@@ -1,0 +1,254 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-1.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.044
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.952
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 4.8000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.8300e+00 atm
+  temperature:
+  - 1.6580e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.6000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9600e+00 atm
+  temperature:
+  - 1.6220e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.2100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.7900e+00 atm
+  temperature:
+  - 1.5040e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.3000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.2100e+00 atm
+  temperature:
+  - 1.6680e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.8000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 1.9200e+00 atm
+  temperature:
+  - 1.5320e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.2000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.1600e+00 atm
+  temperature:
+  - 1.6080e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.6000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.0000e+00 atm
+  temperature:
+  - 1.5250e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.9000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.2300e+00 atm
+  temperature:
+  - 1.6200e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.2900e+00 atm
+  temperature:
+  - 1.6310e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.5000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.2000e+00 atm
+  temperature:
+  - 1.5900e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.4000e+01 us
+  ignition-type: *id002
+  pressure:
+  - 2.1600e+00 atm
+  temperature:
+  - 1.5690e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.4000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0000e+00 atm
+  temperature:
+  - 1.4740e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.3000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0700e+00 atm
+  temperature:
+  - 1.4940e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.6100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8000e+00 atm
+  temperature:
+  - 1.3590e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.5600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8800e+00 atm
+  temperature:
+  - 1.3840e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.7000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1400e+00 atm
+  temperature:
+  - 1.4630e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.9500e+00 atm
+  temperature:
+  - 1.3730e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.9000e+00 atm
+  temperature:
+  - 1.3470e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.6700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.8600e+00 atm
+  temperature:
+  - 1.3140e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.3200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.9500e+00 atm
+  temperature:
+  - 1.3280e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.3700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1500e+00 atm
+  temperature:
+  - 1.3730e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.6100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.1200e+00 atm
+  temperature:
+  - 1.3600e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.5180e+03 us
+  ignition-type: *id002
+  pressure:
+  - 1.9500e+00 atm
+  temperature:
+  - 1.2800e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.7500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.2300e+00 atm
+  temperature:
+  - 1.3870e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.7000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 2.0500e+00 atm
+  temperature:
+  - 1.3110e+03 K
+experiment-type: ignition delay
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-4.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005

--- a/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -17,9 +17,10 @@ reference:
   volume: 37
   year: 2005
 apparatus:
-  facility: ''
-  institution: ''
+  facility: stainless steel shock tube
+  institution: NUI Galway
   kind: shock tube
+experiment-type: ignition delay
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +49,7 @@ datapoints:
   - 1.8300e+00 atm
   temperature:
   - 1.6580e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.6000e+01 us
@@ -56,6 +58,7 @@ datapoints:
   - 1.9600e+00 atm
   temperature:
   - 1.6220e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.2100e+02 us
@@ -64,6 +67,7 @@ datapoints:
   - 1.7900e+00 atm
   temperature:
   - 1.5040e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.3000e+01 us
@@ -72,6 +76,7 @@ datapoints:
   - 2.2100e+00 atm
   temperature:
   - 1.6680e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 9.8000e+01 us
@@ -80,6 +85,7 @@ datapoints:
   - 1.9200e+00 atm
   temperature:
   - 1.5320e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.2000e+01 us
@@ -88,6 +94,7 @@ datapoints:
   - 2.1600e+00 atm
   temperature:
   - 1.6080e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 8.6000e+01 us
@@ -96,6 +103,7 @@ datapoints:
   - 2.0000e+00 atm
   temperature:
   - 1.5250e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.9000e+01 us
@@ -104,6 +112,7 @@ datapoints:
   - 2.2300e+00 atm
   temperature:
   - 1.6200e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.4000e+01 us
@@ -112,6 +121,7 @@ datapoints:
   - 2.2900e+00 atm
   temperature:
   - 1.6310e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.5000e+01 us
@@ -120,6 +130,7 @@ datapoints:
   - 2.2000e+00 atm
   temperature:
   - 1.5900e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 7.4000e+01 us
@@ -128,6 +139,7 @@ datapoints:
   - 2.1600e+00 atm
   temperature:
   - 1.5690e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.4000e+02 us
@@ -136,6 +148,7 @@ datapoints:
   - 2.0000e+00 atm
   temperature:
   - 1.4740e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.3000e+02 us
@@ -144,6 +157,7 @@ datapoints:
   - 2.0700e+00 atm
   temperature:
   - 1.4940e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.6100e+02 us
@@ -152,6 +166,7 @@ datapoints:
   - 1.8000e+00 atm
   temperature:
   - 1.3590e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.5600e+02 us
@@ -160,6 +175,7 @@ datapoints:
   - 1.8800e+00 atm
   temperature:
   - 1.3840e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.7000e+02 us
@@ -168,6 +184,7 @@ datapoints:
   - 2.1400e+00 atm
   temperature:
   - 1.4630e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.3100e+02 us
@@ -176,6 +193,7 @@ datapoints:
   - 1.9500e+00 atm
   temperature:
   - 1.3730e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.3100e+02 us
@@ -184,6 +202,7 @@ datapoints:
   - 1.9000e+00 atm
   temperature:
   - 1.3470e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 8.6700e+02 us
@@ -192,6 +211,7 @@ datapoints:
   - 1.8600e+00 atm
   temperature:
   - 1.3140e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 7.3200e+02 us
@@ -200,6 +220,7 @@ datapoints:
   - 1.9500e+00 atm
   temperature:
   - 1.3280e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.3700e+02 us
@@ -208,6 +229,7 @@ datapoints:
   - 2.1500e+00 atm
   temperature:
   - 1.3730e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.6100e+02 us
@@ -216,6 +238,7 @@ datapoints:
   - 2.1200e+00 atm
   temperature:
   - 1.3600e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.5180e+03 us
@@ -224,6 +247,7 @@ datapoints:
   - 1.9500e+00 atm
   temperature:
   - 1.2800e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.7500e+02 us
@@ -232,6 +256,7 @@ datapoints:
   - 2.2300e+00 atm
   temperature:
   - 1.3870e+03 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 9.7000e+02 us
@@ -240,18 +265,4 @@ datapoints:
   - 2.0500e+00 atm
   temperature:
   - 1.3110e+03 K
-experiment-type: ignition delay
-file-author:
-  name: KE Niemeyer, Oregon State University
-file-version: 0
-reference:
-  authors:
-  - name: John M. Smith
-  - name: John M. Simmie
-  - name: Henry J. Curran
-  detail: Converted from ReSpecTh XML file st_smith_2005-4.xml
-  doi: 10.1002/kin.20120
-  journal: International Journal of Chemical Kinetics
-  pages: 728-736
-  volume: 37
-  year: 2005
+  equivalence-ratio: 1.0

--- a/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-4.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: John M. Smith

--- a/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
@@ -1,0 +1,366 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-1.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.004
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.022
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.974
+      species-name: Ar
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 2.0600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0300e+00 atm
+  temperature:
+  - 1.6540e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.3000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.6510e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.6000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0900e+00 atm
+  temperature:
+  - 1.6880e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.4600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.6410e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.8700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0700e+00 atm
+  temperature:
+  - 1.6580e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.6100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1200e+00 atm
+  temperature:
+  - 1.7090e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.5400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1300e+00 atm
+  temperature:
+  - 1.7160e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.7400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0300e+00 atm
+  temperature:
+  - 1.6080e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.0400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.6150e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.2300e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.6420e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.0600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1100e+00 atm
+  temperature:
+  - 1.6340e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.4000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1200e+00 atm
+  temperature:
+  - 1.6210e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.5400e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.5030e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.4600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1300e+00 atm
+  temperature:
+  - 1.6320e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.9600e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1800e+00 atm
+  temperature:
+  - 1.6730e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.0200e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0000e+00 atm
+  temperature:
+  - 1.5060e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.1800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.5530e+03 K
+- composition: *id001
+  ignition-delay:
+  - 5.1500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0300e+00 atm
+  temperature:
+  - 1.5180e+03 K
+- composition: *id001
+  ignition-delay:
+  - 8.7700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.4000e-01 atm
+  temperature:
+  - 1.4280e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.6620e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.9500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0600e+00 atm
+  temperature:
+  - 1.5340e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.9000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.6120e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.2000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.6050e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.1000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1500e+00 atm
+  temperature:
+  - 1.6030e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.1000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.5150e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.1800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.2000e+00 atm
+  temperature:
+  - 1.6430e+03 K
+- composition: *id001
+  ignition-delay:
+  - 2.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1700e+00 atm
+  temperature:
+  - 1.6190e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.5500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0200e+00 atm
+  temperature:
+  - 1.4810e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.3100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.5620e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.3500e+02 us
+  ignition-type: *id002
+  pressure:
+  - 9.6000e-01 atm
+  temperature:
+  - 1.4220e+03 K
+- composition: *id001
+  ignition-delay:
+  - 7.4000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0300e+00 atm
+  temperature:
+  - 1.4830e+03 K
+- composition: *id001
+  ignition-delay:
+  - 1.0040e+03 us
+  ignition-type: *id002
+  pressure:
+  - 9.7000e-01 atm
+  temperature:
+  - 1.4200e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.9800e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1000e+00 atm
+  temperature:
+  - 1.5390e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.0700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0500e+00 atm
+  temperature:
+  - 1.4980e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.4700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1100e+00 atm
+  temperature:
+  - 1.5360e+03 K
+- composition: *id001
+  ignition-delay:
+  - 6.1700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0900e+00 atm
+  temperature:
+  - 1.5150e+03 K
+- composition: *id001
+  ignition-delay:
+  - 9.3700e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.0400e+00 atm
+  temperature:
+  - 1.4600e+03 K
+- composition: *id001
+  ignition-delay:
+  - 3.7100e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1300e+00 atm
+  temperature:
+  - 1.5380e+03 K
+- composition: *id001
+  ignition-delay:
+  - 4.1000e+02 us
+  ignition-type: *id002
+  pressure:
+  - 1.1400e+00 atm
+  temperature:
+  - 1.5330e+03 K
+experiment-type: ignition delay
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+reference:
+  authors:
+  - name: John M. Smith
+  - name: John M. Simmie
+  - name: Henry J. Curran
+  detail: Converted from ReSpecTh XML file st_smith_2005-5.xml
+  doi: 10.1002/kin.20120
+  journal: International Journal of Chemical Kinetics
+  pages: 728-736
+  volume: 37
+  year: 2005

--- a/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -17,9 +17,10 @@ reference:
   volume: 37
   year: 2005
 apparatus:
-  facility: ''
-  institution: ''
+  facility: stainless steel shock tube
+  institution: NUI Galway
   kind: shock tube
+experiment-type: ignition delay
 common-properties:
   composition: &id001
     kind: mole fraction
@@ -48,6 +49,7 @@ datapoints:
   - 1.0300e+00 atm
   temperature:
   - 1.6540e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.3000e+02 us
@@ -56,6 +58,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.6510e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 1.6000e+02 us
@@ -64,6 +67,7 @@ datapoints:
   - 1.0900e+00 atm
   temperature:
   - 1.6880e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.4600e+02 us
@@ -72,6 +76,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.6410e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 1.8700e+02 us
@@ -80,6 +85,7 @@ datapoints:
   - 1.0700e+00 atm
   temperature:
   - 1.6580e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 1.6100e+02 us
@@ -88,6 +94,7 @@ datapoints:
   - 1.1200e+00 atm
   temperature:
   - 1.7090e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 1.5400e+02 us
@@ -96,6 +103,7 @@ datapoints:
   - 1.1300e+00 atm
   temperature:
   - 1.7160e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.7400e+02 us
@@ -104,6 +112,7 @@ datapoints:
   - 1.0300e+00 atm
   temperature:
   - 1.6080e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.0400e+02 us
@@ -112,6 +121,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.6150e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.2300e+02 us
@@ -120,6 +130,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.6420e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.0600e+02 us
@@ -128,6 +139,7 @@ datapoints:
   - 1.1100e+00 atm
   temperature:
   - 1.6340e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.4000e+02 us
@@ -136,6 +148,7 @@ datapoints:
   - 1.1200e+00 atm
   temperature:
   - 1.6210e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 5.5400e+02 us
@@ -144,6 +157,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.5030e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.4600e+02 us
@@ -152,6 +166,7 @@ datapoints:
   - 1.1300e+00 atm
   temperature:
   - 1.6320e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 1.9600e+02 us
@@ -160,6 +175,7 @@ datapoints:
   - 1.1800e+00 atm
   temperature:
   - 1.6730e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 7.0200e+02 us
@@ -168,6 +184,7 @@ datapoints:
   - 1.0000e+00 atm
   temperature:
   - 1.5060e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 4.1800e+02 us
@@ -176,6 +193,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.5530e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 5.1500e+02 us
@@ -184,6 +202,7 @@ datapoints:
   - 1.0300e+00 atm
   temperature:
   - 1.5180e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 8.7700e+02 us
@@ -192,6 +211,7 @@ datapoints:
   - 9.4000e-01 atm
   temperature:
   - 1.4280e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.1000e+02 us
@@ -200,6 +220,7 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.6620e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.9500e+02 us
@@ -208,6 +229,7 @@ datapoints:
   - 1.0600e+00 atm
   temperature:
   - 1.5340e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.9000e+02 us
@@ -216,6 +238,7 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.6120e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.2000e+02 us
@@ -224,6 +247,7 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.6050e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.1000e+02 us
@@ -232,6 +256,7 @@ datapoints:
   - 1.1500e+00 atm
   temperature:
   - 1.6030e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 6.1000e+02 us
@@ -240,6 +265,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.5150e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.1800e+02 us
@@ -248,6 +274,7 @@ datapoints:
   - 1.2000e+00 atm
   temperature:
   - 1.6430e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 2.3100e+02 us
@@ -256,6 +283,7 @@ datapoints:
   - 1.1700e+00 atm
   temperature:
   - 1.6190e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 7.5500e+02 us
@@ -264,6 +292,7 @@ datapoints:
   - 1.0200e+00 atm
   temperature:
   - 1.4810e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.3100e+02 us
@@ -272,6 +301,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.5620e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 9.3500e+02 us
@@ -280,6 +310,7 @@ datapoints:
   - 9.6000e-01 atm
   temperature:
   - 1.4220e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 7.4000e+02 us
@@ -288,6 +319,7 @@ datapoints:
   - 1.0300e+00 atm
   temperature:
   - 1.4830e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 1.0040e+03 us
@@ -296,6 +328,7 @@ datapoints:
   - 9.7000e-01 atm
   temperature:
   - 1.4200e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.9800e+02 us
@@ -304,6 +337,7 @@ datapoints:
   - 1.1000e+00 atm
   temperature:
   - 1.5390e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 6.0700e+02 us
@@ -312,6 +346,7 @@ datapoints:
   - 1.0500e+00 atm
   temperature:
   - 1.4980e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 4.4700e+02 us
@@ -320,6 +355,7 @@ datapoints:
   - 1.1100e+00 atm
   temperature:
   - 1.5360e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 6.1700e+02 us
@@ -328,6 +364,7 @@ datapoints:
   - 1.0900e+00 atm
   temperature:
   - 1.5150e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 9.3700e+02 us
@@ -336,6 +373,7 @@ datapoints:
   - 1.0400e+00 atm
   temperature:
   - 1.4600e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 3.7100e+02 us
@@ -344,6 +382,7 @@ datapoints:
   - 1.1300e+00 atm
   temperature:
   - 1.5380e+03 K
+  equivalence-ratio: 2.0
 - composition: *id001
   ignition-delay:
   - 4.1000e+02 us
@@ -352,18 +391,4 @@ datapoints:
   - 1.1400e+00 atm
   temperature:
   - 1.5330e+03 K
-experiment-type: ignition delay
-file-author:
-  name: KE Niemeyer, Oregon State University
-file-version: 0
-reference:
-  authors:
-  - name: John M. Smith
-  - name: John M. Simmie
-  - name: Henry J. Curran
-  detail: Converted from ReSpecTh XML file st_smith_2005-5.xml
-  doi: 10.1002/kin.20120
-  journal: International Journal of Chemical Kinetics
-  pages: 728-736
-  volume: 37
-  year: 2005
+  equivalence-ratio: 2.0

--- a/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
+++ b/n-heptane/Smith et al. 2005/st_smith_2005-5.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: John M. Smith

--- a/n-heptane/Vandersickel 2012/st_vandersickel_2012-1.yaml
+++ b/n-heptane/Vandersickel 2012/st_vandersickel_2012-1.yaml
@@ -1,0 +1,78 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: A. Vandersickel
+    - name: M. Hartmann
+    - name: K. Vogel
+    - name: Y. M. Wright
+    - name: M. Fikri
+    - name: R. Starke
+    - name: C. Schulz
+    - name: K. Boulouchos
+  journal: Fuel
+  year: 2012
+  volume: 93
+  pages: 492-501
+  doi: 10.1016/j.fuel.2011.10.062
+  detail: Converted from ReSpecTh XML file st_vandersickel_2012-1.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Institute of Energy Technology, Zürich
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.00887
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1457
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.84543
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 4685 us
+  ignition-type: *id002
+  temperature:
+  - 714 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 20.3 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 3628 us
+  ignition-type: *id002
+  temperature:
+  - 759 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 17 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67

--- a/n-heptane/Vandersickel 2012/st_vandersickel_2012-2.yaml
+++ b/n-heptane/Vandersickel 2012/st_vandersickel_2012-2.yaml
@@ -1,0 +1,183 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: A. Vandersickel
+    - name: M. Hartmann
+    - name: K. Vogel
+    - name: Y. M. Wright
+    - name: M. Fikri
+    - name: R. Starke
+    - name: C. Schulz
+    - name: K. Boulouchos
+  journal: Fuel
+  year: 2012
+  volume: 93
+  pages: 492-501
+  doi: 10.1016/j.fuel.2011.10.062
+  detail: Converted from ReSpecTh XML file st_vandersickel_2012-2.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Institute of Energy Technology, Zürich
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.00887
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1457
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.84543
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1996 us
+  ignition-type: *id002
+  temperature:
+  - 726 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.3 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 1076 us
+  ignition-type: *id002
+  temperature:
+  - 780 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 44.2 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 932 us
+  ignition-type: *id002
+  temperature:
+  - 793 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 47 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 910 us
+  ignition-type: *id002
+  temperature:
+  - 832 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 44.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 1009 us
+  ignition-type: *id002
+  temperature:
+  - 875 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.6 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 1101 us
+  ignition-type: *id002
+  temperature:
+  - 945 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 45.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 887 us
+  ignition-type: *id002
+  temperature:
+  - 988 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 44.3 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 705 us
+  ignition-type: *id002
+  temperature:
+  - 994 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 39.6 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 358 us
+  ignition-type: *id002
+  temperature:
+  - 1094 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 39.8 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67

--- a/n-heptane/Vandersickel 2012/st_vandersickel_2012-3.yaml
+++ b/n-heptane/Vandersickel 2012/st_vandersickel_2012-3.yaml
@@ -1,0 +1,153 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: A. Vandersickel
+    - name: M. Hartmann
+    - name: K. Vogel
+    - name: Y. M. Wright
+    - name: M. Fikri
+    - name: R. Starke
+    - name: C. Schulz
+    - name: K. Boulouchos
+  journal: Fuel
+  year: 2012
+  volume: 93
+  pages: 492-501
+  doi: 10.1016/j.fuel.2011.10.062
+  detail: Converted from ReSpecTh XML file st_vandersickel_2012-3.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Institute of Energy Technology, Zürich
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.00887
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1457
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.84543
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1257 us
+  ignition-type: *id002
+  temperature:
+  - 753 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 65.1 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 952 us
+  ignition-type: *id002
+  temperature:
+  - 785 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 63.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 638 us
+  ignition-type: *id002
+  temperature:
+  - 827 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 64.4 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 578 us
+  ignition-type: *id002
+  temperature:
+  - 879 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 62.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 631 us
+  ignition-type: *id002
+  temperature:
+  - 936 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 63.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 576 us
+  ignition-type: *id002
+  temperature:
+  - 1000 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 65.1 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 325 us
+  ignition-type: *id002
+  temperature:
+  - 1059 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 66.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67

--- a/n-heptane/Vandersickel 2012/st_vandersickel_2012-4.yaml
+++ b/n-heptane/Vandersickel 2012/st_vandersickel_2012-4.yaml
@@ -1,0 +1,108 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: A. Vandersickel
+    - name: M. Hartmann
+    - name: K. Vogel
+    - name: Y. M. Wright
+    - name: M. Fikri
+    - name: R. Starke
+    - name: C. Schulz
+    - name: K. Boulouchos
+  journal: Fuel
+  year: 2012
+  volume: 93
+  pages: 492-501
+  doi: 10.1016/j.fuel.2011.10.062
+  detail: Converted from ReSpecTh XML file st_vandersickel_2012-4.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Institute of Energy Technology, Zürich
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0066375
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1460243
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.8473382
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 3590 us
+  ignition-type: *id002
+  temperature:
+  - 716 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.4 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 1713 us
+  ignition-type: *id002
+  temperature:
+  - 796 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 41 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 1596 us
+  ignition-type: *id002
+  temperature:
+  - 913 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.2 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.5
+- composition: *id001
+  ignition-delay:
+  - 880 us
+  ignition-type: *id002
+  temperature:
+  - 1002 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.8 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.5

--- a/n-heptane/Vandersickel 2012/st_vandersickel_2012-5.yaml
+++ b/n-heptane/Vandersickel 2012/st_vandersickel_2012-5.yaml
@@ -1,0 +1,288 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: A. Vandersickel
+    - name: M. Hartmann
+    - name: K. Vogel
+    - name: Y. M. Wright
+    - name: M. Fikri
+    - name: R. Starke
+    - name: C. Schulz
+    - name: K. Boulouchos
+  journal: Fuel
+  year: 2012
+  volume: 93
+  pages: 492-501
+  doi: 10.1016/j.fuel.2011.10.062
+  detail: Converted from ReSpecTh XML file st_vandersickel_2012-5.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Institute of Energy Technology, Zürich
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.012634
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20743
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.779936
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 3029 us
+  ignition-type: *id002
+  temperature:
+  - 698 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 37.4 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 3228 us
+  ignition-type: *id002
+  temperature:
+  - 701 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 37.1 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 2518 us
+  ignition-type: *id002
+  temperature:
+  - 714 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.8 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 1084 us
+  ignition-type: *id002
+  temperature:
+  - 743 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 41.7 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 726 us
+  ignition-type: *id002
+  temperature:
+  - 772 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.9 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 545 us
+  ignition-type: *id002
+  temperature:
+  - 804 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 570 us
+  ignition-type: *id002
+  temperature:
+  - 817 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 41.7 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 657 us
+  ignition-type: *id002
+  temperature:
+  - 889 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 38.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 475 us
+  ignition-type: *id002
+  temperature:
+  - 897 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 44.6 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 505 us
+  ignition-type: *id002
+  temperature:
+  - 940 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 41.2 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 509 us
+  ignition-type: *id002
+  temperature:
+  - 969 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 44.2 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 576 us
+  ignition-type: *id002
+  temperature:
+  - 1009 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 343 us
+  ignition-type: *id002
+  temperature:
+  - 1029 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.2 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 189 us
+  ignition-type: *id002
+  temperature:
+  - 1099 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 41.2 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 143 us
+  ignition-type: *id002
+  temperature:
+  - 1117 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.7 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 30 us
+  ignition-type: *id002
+  temperature:
+  - 1153 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.2 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67

--- a/n-heptane/Vandersickel 2012/st_vandersickel_2012-6.yaml
+++ b/n-heptane/Vandersickel 2012/st_vandersickel_2012-6.yaml
@@ -1,0 +1,108 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: A. Vandersickel
+    - name: M. Hartmann
+    - name: K. Vogel
+    - name: Y. M. Wright
+    - name: M. Fikri
+    - name: R. Starke
+    - name: C. Schulz
+    - name: K. Boulouchos
+  journal: Fuel
+  year: 2012
+  volume: 93
+  pages: 492-501
+  doi: 10.1016/j.fuel.2011.10.062
+  detail: Converted from ReSpecTh XML file st_vandersickel_2012-6.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Institute of Energy Technology, Zürich
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0063548
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1043327
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.8893125
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 4963 us
+  ignition-type: *id002
+  temperature:
+  - 711 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.9 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 3021 us
+  ignition-type: *id002
+  temperature:
+  - 793 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 39.6 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 2557 us
+  ignition-type: *id002
+  temperature:
+  - 906 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.9 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67
+- composition: *id001
+  ignition-delay:
+  - 1268 us
+  ignition-type: *id002
+  temperature:
+  - 1011 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.5 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 0.67

--- a/n-heptane/Vandersickel 2012/st_vandersickel_2012-7.yaml
+++ b/n-heptane/Vandersickel 2012/st_vandersickel_2012-7.yaml
@@ -1,0 +1,153 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: A. Vandersickel
+    - name: M. Hartmann
+    - name: K. Vogel
+    - name: Y. M. Wright
+    - name: M. Fikri
+    - name: R. Starke
+    - name: C. Schulz
+    - name: K. Boulouchos
+  journal: Fuel
+  year: 2012
+  volume: 93
+  pages: 492-501
+  doi: 10.1016/j.fuel.2011.10.062
+  detail: Converted from ReSpecTh XML file st_vandersickel_2012-7.xml
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Institute of Energy Technology, Zürich
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0131874
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.1450615
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.8417511
+      species-name: N2
+  ignition-type: &id002
+    target: CH*
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 5267 us
+  ignition-type: *id002
+  temperature:
+  - 679 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 36 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 3842 us
+  ignition-type: *id002
+  temperature:
+  - 693 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 38.1 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1157 us
+  ignition-type: *id002
+  temperature:
+  - 773 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 36.6 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 856 us
+  ignition-type: *id002
+  temperature:
+  - 803 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.6 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 923 us
+  ignition-type: *id002
+  temperature:
+  - 887 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 38.8 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 890 us
+  ignition-type: *id002
+  temperature:
+  - 976 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 42.3 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 759 us
+  ignition-type: *id002
+  temperature:
+  - 996 kelvin
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure:
+  - 40.9 bar
+  - uncertainty-type: relative
+    uncertainty: 0.02
+  pressure-rise:
+  - 0.03 1/ms
+  equivalence-ratio: 1

--- a/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
+++ b/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
@@ -1,0 +1,328 @@
+file-author:
+  name: KE Niemeyer, Oregon State University
+file-version: 0
+chemked-version: 0.3.0
+reference:
+  authors:
+  - name: D.J. Vermeer
+  - name: J.W. Meyer
+  - name: A.K. Oppenheim
+  detail: Converted from ReSpecTh XML file st_vermeer_1972.xml
+  doi: 10.1016/S0010-2180(72)80183-4
+  journal: Combustion and Flame
+  pages: 327-336
+  volume: 18
+  year: 1972
+apparatus:
+  facility: ''
+  institution: ''
+  kind: shock tube
+experiment-type: ignition delay
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.025
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.275
+      species-name: O2
+    - InChI: 1S/Ar
+      amount:
+      - 0.7
+      species-name: Ar
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints:
+- composition: *id001
+  ignition-delay:
+  - 1.3000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.6600e0 atm
+  temperature:
+  - 1.5800e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.8000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.5600e0 atm
+  temperature:
+  - 1.5550e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.0000e1 us
+  ignition-type: *id002
+  pressure:
+  - 4.0900e0 atm
+  temperature:
+  - 1.5300e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.3000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.6100e0 atm
+  temperature:
+  - 1.5450e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.3000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.6000e0 atm
+  temperature:
+  - 1.5300e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.5000e1 us
+  ignition-type: *id002
+  pressure:
+  - 1.8000e0 atm
+  temperature:
+  - 1.5500e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.2000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.5000e0 atm
+  temperature:
+  - 1.5050e3 K
+- composition: *id001
+  ignition-delay:
+  - 4.0000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.4100e0 atm
+  temperature:
+  - 1.4800e3 K
+- composition: *id001
+  ignition-delay:
+  - 6.5000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.1400e0 atm
+  temperature:
+  - 1.4250e3 K
+- composition: *id001
+  ignition-delay:
+  - 6.5000e1 us
+  ignition-type: *id002
+  pressure:
+  - 1.6000e0 atm
+  temperature:
+  - 1.4300e3 K
+- composition: *id001
+  ignition-delay:
+  - 6.8000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.3400e0 atm
+  temperature:
+  - 1.4500e3 K
+- composition: *id001
+  ignition-delay:
+  - 8.0000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.3800e0 atm
+  temperature:
+  - 1.4200e3 K
+- composition: *id001
+  ignition-delay:
+  - 8.0000e1 us
+  ignition-type: *id002
+  pressure:
+  - 2.2800e0 atm
+  temperature:
+  - 1.4150e3 K
+- composition: *id001
+  ignition-delay:
+  - 8.0000e1 us
+  ignition-type: *id002
+  pressure:
+  - 3.3400e0 atm
+  temperature:
+  - 1.3700e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.0000e2 us
+  ignition-type: *id002
+  pressure:
+  - 1.5200e0 atm
+  temperature:
+  - 1.4000e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.0500e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.3200e0 atm
+  temperature:
+  - 1.3800e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.3500e2 us
+  ignition-type: *id002
+  pressure:
+  - 3.5200e0 atm
+  temperature:
+  - 1.3400e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.6000e2 us
+  ignition-type: *id002
+  pressure:
+  - 1.5200e0 atm
+  temperature:
+  - 1.4100e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.7000e2 us
+  ignition-type: *id002
+  pressure:
+  - 3.3000e0 atm
+  temperature:
+  - 1.3200e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.8500e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.1400e0 atm
+  temperature:
+  - 1.3700e3 K
+- composition: *id001
+  ignition-delay:
+  - 1.9000e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.1800e0 atm
+  temperature:
+  - 1.3600e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.0500e2 us
+  ignition-type: *id002
+  pressure:
+  - 3.0600e0 atm
+  temperature:
+  - 1.3100e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.1000e2 us
+  ignition-type: *id002
+  pressure:
+  - 1.3800e0 atm
+  temperature:
+  - 1.3550e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.3500e2 us
+  ignition-type: *id002
+  pressure:
+  - 3.0700e0 atm
+  temperature:
+  - 1.3100e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.4000e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.1100e0 atm
+  temperature:
+  - 1.3250e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.4000e2 us
+  ignition-type: *id002
+  pressure:
+  - 1.4300e0 atm
+  temperature:
+  - 1.3700e3 K
+- composition: *id001
+  ignition-delay:
+  - 2.5500e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.8900e0 atm
+  temperature:
+  - 1.2900e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.4000e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.0900e0 atm
+  temperature:
+  - 1.3200e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.4000e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.2400e0 atm
+  temperature:
+  - 1.2950e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.5000e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.1000e0 atm
+  temperature:
+  - 1.3100e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.6500e2 us
+  ignition-type: *id002
+  pressure:
+  - 1.9800e0 atm
+  temperature:
+  - 1.2900e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.7500e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.1700e0 atm
+  temperature:
+  - 1.3000e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.7500e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.2100e0 atm
+  temperature:
+  - 1.2700e3 K
+- composition: *id001
+  ignition-delay:
+  - 3.8500e2 us
+  ignition-type: *id002
+  pressure:
+  - 2.9200e0 atm
+  temperature:
+  - 1.2700e3 K
+- composition: *id001
+  ignition-delay:
+  - 4.5000e2 us
+  ignition-type: *id002
+  pressure:
+  - 1.3500e0 atm
+  temperature:
+  - 1.3300e3 K
+- composition: *id001
+  ignition-delay:
+  - 5.3000e2 us
+  ignition-type: *id002
+  pressure:
+  - 1.9400e0 atm
+  temperature:
+  - 1.2700e3 K

--- a/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
+++ b/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
@@ -1,7 +1,8 @@
-file-author:
+file-authors:
   name: KE Niemeyer, Oregon State University
+  name: Bradley Carrano
 file-version: 0
-chemked-version: 0.3.0
+chemked-version: 0.4.1
 reference:
   authors:
   - name: D.J. Vermeer

--- a/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
+++ b/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
@@ -1,8 +1,8 @@
 file-authors:
-  - name: Kyle Niemeyer
   - name: Bradley Carrano
     ORCID: 0000-0003-3700-4155
-
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
 file-version: 0
 chemked-version: 0.4.1
 reference:
@@ -18,7 +18,7 @@ reference:
   year: 1972
 apparatus:
   facility: ''
-  institution: ''
+  institution: University of California
   kind: shock tube
 experiment-type: ignition delay
 common-properties:
@@ -49,6 +49,7 @@ datapoints:
   - 2.6600e0 atm
   temperature:
   - 1.5800e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.8000e1 us
@@ -57,6 +58,7 @@ datapoints:
   - 2.5600e0 atm
   temperature:
   - 1.5550e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.0000e1 us
@@ -65,6 +67,7 @@ datapoints:
   - 4.0900e0 atm
   temperature:
   - 1.5300e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.3000e1 us
@@ -73,6 +76,7 @@ datapoints:
   - 2.6100e0 atm
   temperature:
   - 1.5450e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.3000e1 us
@@ -81,6 +85,7 @@ datapoints:
   - 2.6000e0 atm
   temperature:
   - 1.5300e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.5000e1 us
@@ -89,6 +94,7 @@ datapoints:
   - 1.8000e0 atm
   temperature:
   - 1.5500e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.2000e1 us
@@ -97,6 +103,7 @@ datapoints:
   - 2.5000e0 atm
   temperature:
   - 1.5050e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.0000e1 us
@@ -105,6 +112,7 @@ datapoints:
   - 2.4100e0 atm
   temperature:
   - 1.4800e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.5000e1 us
@@ -113,6 +121,7 @@ datapoints:
   - 2.1400e0 atm
   temperature:
   - 1.4250e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.5000e1 us
@@ -121,6 +130,7 @@ datapoints:
   - 1.6000e0 atm
   temperature:
   - 1.4300e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 6.8000e1 us
@@ -129,6 +139,7 @@ datapoints:
   - 2.3400e0 atm
   temperature:
   - 1.4500e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 8.0000e1 us
@@ -137,6 +148,7 @@ datapoints:
   - 2.3800e0 atm
   temperature:
   - 1.4200e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 8.0000e1 us
@@ -145,6 +157,7 @@ datapoints:
   - 2.2800e0 atm
   temperature:
   - 1.4150e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 8.0000e1 us
@@ -153,6 +166,7 @@ datapoints:
   - 3.3400e0 atm
   temperature:
   - 1.3700e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.0000e2 us
@@ -161,6 +175,7 @@ datapoints:
   - 1.5200e0 atm
   temperature:
   - 1.4000e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.0500e2 us
@@ -169,6 +184,7 @@ datapoints:
   - 2.3200e0 atm
   temperature:
   - 1.3800e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.3500e2 us
@@ -177,6 +193,7 @@ datapoints:
   - 3.5200e0 atm
   temperature:
   - 1.3400e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.6000e2 us
@@ -185,6 +202,7 @@ datapoints:
   - 1.5200e0 atm
   temperature:
   - 1.4100e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.7000e2 us
@@ -193,6 +211,7 @@ datapoints:
   - 3.3000e0 atm
   temperature:
   - 1.3200e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.8500e2 us
@@ -201,6 +220,7 @@ datapoints:
   - 2.1400e0 atm
   temperature:
   - 1.3700e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 1.9000e2 us
@@ -209,6 +229,7 @@ datapoints:
   - 2.1800e0 atm
   temperature:
   - 1.3600e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.0500e2 us
@@ -217,6 +238,7 @@ datapoints:
   - 3.0600e0 atm
   temperature:
   - 1.3100e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.1000e2 us
@@ -225,6 +247,7 @@ datapoints:
   - 1.3800e0 atm
   temperature:
   - 1.3550e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.3500e2 us
@@ -233,6 +256,7 @@ datapoints:
   - 3.0700e0 atm
   temperature:
   - 1.3100e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.4000e2 us
@@ -241,6 +265,7 @@ datapoints:
   - 2.1100e0 atm
   temperature:
   - 1.3250e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.4000e2 us
@@ -249,6 +274,7 @@ datapoints:
   - 1.4300e0 atm
   temperature:
   - 1.3700e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 2.5500e2 us
@@ -257,6 +283,7 @@ datapoints:
   - 2.8900e0 atm
   temperature:
   - 1.2900e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.4000e2 us
@@ -265,6 +292,7 @@ datapoints:
   - 2.0900e0 atm
   temperature:
   - 1.3200e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.4000e2 us
@@ -273,6 +301,7 @@ datapoints:
   - 2.2400e0 atm
   temperature:
   - 1.2950e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.5000e2 us
@@ -281,6 +310,7 @@ datapoints:
   - 2.1000e0 atm
   temperature:
   - 1.3100e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.6500e2 us
@@ -289,6 +319,7 @@ datapoints:
   - 1.9800e0 atm
   temperature:
   - 1.2900e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.7500e2 us
@@ -297,6 +328,7 @@ datapoints:
   - 2.1700e0 atm
   temperature:
   - 1.3000e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.7500e2 us
@@ -305,6 +337,7 @@ datapoints:
   - 2.2100e0 atm
   temperature:
   - 1.2700e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 3.8500e2 us
@@ -313,6 +346,7 @@ datapoints:
   - 2.9200e0 atm
   temperature:
   - 1.2700e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 4.5000e2 us
@@ -321,6 +355,7 @@ datapoints:
   - 1.3500e0 atm
   temperature:
   - 1.3300e3 K
+  equivalence-ratio: 1.0
 - composition: *id001
   ignition-delay:
   - 5.3000e2 us
@@ -329,3 +364,4 @@ datapoints:
   - 1.9400e0 atm
   temperature:
   - 1.2700e3 K
+  equivalence-ratio: 1.0

--- a/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
+++ b/n-heptane/Vermeer 1972/st_vermeer_1972.yaml
@@ -1,6 +1,8 @@
 file-authors:
-  name: KE Niemeyer, Oregon State University
-  name: Bradley Carrano
+  - name: Kyle Niemeyer
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+
 file-version: 0
 chemked-version: 0.4.1
 reference:

--- a/n-heptane/Zhang 2016/st_zhang_2016-1.yaml
+++ b/n-heptane/Zhang 2016/st_zhang_2016-1.yaml
@@ -1,0 +1,194 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Kuiwen Zhang
+      ORCID: 0000-0002-2460-2036 
+    - name: Colin Banyon
+    - name: John Bugler
+    - name: Henry J. Curran
+      ORCID: 0000-0002-5124-8562
+    - name: Anne Rodriguez
+    - name: Oliver Herbinet
+    - name: Frederique Battin-Leclerc
+    - name: Christine B'Chir
+    - name: Karl Alexander Heufer
+  journal: Combustion and Flame
+  year: 2016
+  volume: 172
+  pages: 116-135
+  doi: 10.1016/j.combustflame.2016.06.028
+  detail: Data from xlsx file experimental data.xlsx
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Aachen University
+  facility: PCFC 
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.018733608092918696
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20606968902210565
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.7751967028849757
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 2 ms
+  ignition-type: *id002
+  temperature:
+  - 726.78 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1.27 ms
+  ignition-type: *id002
+  temperature:
+  - 770 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1.09 ms
+  ignition-type: *id002
+  temperature:
+  - 817.44 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1.29 ms
+  ignition-type: *id002
+  temperature:
+  - 853.54 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1.7 ms
+  ignition-type: *id002
+  temperature:
+  - 904.37 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1.48 ms
+  ignition-type: *id002
+  temperature:
+  - 947.05 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 1.05 ms
+  ignition-type: *id002
+  temperature:
+  - 999 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.58 ms
+  ignition-type: *id002
+  temperature:
+  - 1066 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.25 ms
+  ignition-type: *id002
+  temperature:
+  - 1145 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.1 ms
+  ignition-type: *id002
+  temperature:
+  - 1238.94 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.02 ms
+  ignition-type: *id002
+  temperature:
+  - 1412.96 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 20 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1

--- a/n-heptane/Zhang 2016/st_zhang_2016-2.yaml
+++ b/n-heptane/Zhang 2016/st_zhang_2016-2.yaml
@@ -1,0 +1,142 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Kuiwen Zhang
+      ORCID: 0000-0002-2460-2036 
+    - name: Colin Banyon
+    - name: John Bugler
+    - name: Henry J. Curran
+      ORCID: 0000-0002-5124-8562
+    - name: Anne Rodriguez
+    - name: Oliver Herbinet
+    - name: Frederique Battin-Leclerc
+    - name: Christine B'Chir
+    - name: Karl Alexander Heufer
+  journal: Combustion and Flame
+  year: 2016
+  volume: 172
+  pages: 116-135
+  doi: 10.1016/j.combustflame.2016.06.028
+  detail: Data from xlsx file experimental data.xlsx
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: Aachen University
+  facility: PCFC
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.018733608092918696
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.20606968902210565
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.7751967028849757
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 0.92 ms
+  ignition-type: *id002
+  temperature:
+  - 755 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 38 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.52 ms
+  ignition-type: *id002
+  temperature:
+  - 798.5 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 38 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.52 ms
+  ignition-type: *id002
+  temperature:
+  - 945 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 38 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.34 ms
+  ignition-type: *id002
+  temperature:
+  - 1046 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 38 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.4 ms
+  ignition-type: *id002
+  temperature:
+  - 902.81 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 38 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.41 ms
+  ignition-type: *id002
+  temperature:
+  - 834.31 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 38 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 0.13 ms
+  ignition-type: *id002
+  temperature:
+  - 1150.71 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 38 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1

--- a/n-heptane/Zhang 2016/st_zhang_2016-3.yaml
+++ b/n-heptane/Zhang 2016/st_zhang_2016-3.yaml
@@ -1,0 +1,129 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+reference:
+  authors:
+    - name: Kuiwen Zhang
+      ORCID: 0000-0002-2460-2036 
+    - name: Colin Banyon
+    - name: John Bugler
+    - name: Henry J. Curran
+      ORCID: 0000-0002-5124-8562
+    - name: Anne Rodriguez
+    - name: Oliver Herbinet
+    - name: Frederique Battin-Leclerc
+    - name: Christine B'Chir
+    - name: Karl Alexander Heufer
+  journal: Combustion and Flame
+  year: 2016
+  volume: 172
+  pages: 116-135
+  doi: 10.1016/j.combustflame.2016.06.028
+  detail: Data from xlsx file experimental data.xlsx
+experiment-type: ignition delay
+apparatus:
+  kind: shock tube
+  institution: NUI Galway
+  facility: high pressure shock tube
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.0179
+      species-name: nC7H16
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.2063
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.7758
+      species-name: N2
+  ignition-type: &id002
+    target: pressure
+    type: d/dt max
+datapoints: 
+- composition: *id001
+  ignition-delay:
+  - 1041 ms
+  ignition-type: *id002
+  temperature:
+  - 1058 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 15 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 667.2 ms
+  ignition-type: *id002
+  temperature:
+  - 1108.1 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 15 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 412.8 ms
+  ignition-type: *id002
+  temperature:
+  - 1155.8 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 15 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 252.97 ms
+  ignition-type: *id002
+  temperature:
+  - 1209.5 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 15 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 149.796 ms
+  ignition-type: *id002
+  temperature:
+  - 1253.4 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 15 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1
+- composition: *id001
+  ignition-delay:
+  - 90.997 ms
+  ignition-type: *id002
+  temperature:
+  - 1297.5 kelvin
+  - uncertainty-type: absolute
+    uncertainty: 2 kelvin
+  pressure:
+  - 15 bar
+  - uncertainty-type: absolute
+    uncertainty: 0.0015 bar
+  equivalence-ratio: 1


### PR DESCRIPTION
This is a new branch for the n heptane data, with the methyl decanoate data removed from the root directory. I believe that all previous errors should be corrected. 