### PR TITLE
Add jet-fuels shock tube ignition data from 10.1016/j.fuel.2016.09.047

### DIFF
--- a/jetfuels/Davidson2016.yaml
+++ b/jetfuels/Davidson2016.yaml
@@ -1,0 +1,3973 @@
+---
+file-authors:
+  - {ORCID: 0000-0002-0303-4711, name: Nicholas Curtis}
+file-version: 0
+chemked-version: 0.4.0
+experiment-type: ignition delay
+apparatus:
+  facility: stainless steel shock tube
+  institution: Stanford,
+  kind: shock tube
+reference:
+  authors:
+    - {name: D.F. Davidson}
+    - {name: Y. Zhu}
+    - {name: J. Shao}
+    - {name: R.K. Hanson}
+  detail: "Jet A data from supplimentary of:
+           'Ignition delay time correlations for distillate fuels'
+           Absolute uncertainty in tau +/- 15%."
+  doi: 10.1016/j.fuel.2016.09.047
+  journal: Fuel
+  pages: 26-32
+  volume: 187
+  year: 2017
+datapoints:
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01544637843907917]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7745536215609208]
+          species-name: Ar
+    equivalence-ratio: 1.31
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 112.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.1 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1219.5 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01780964002440513]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7721903599755949]
+          species-name: Ar
+    equivalence-ratio: 1.529
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 257.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.9 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1120.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.016640625]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20999999999999996]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.773359375]
+          species-name: Ar
+    equivalence-ratio: 1.42
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 149.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.0 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1188.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.007368421052631576]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20999999999999996]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7826315789473683]
+          species-name: Ar
+    equivalence-ratio: 0.6
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 729.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.26 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1054.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.010173010380622837]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7798269896193771]
+          species-name: Ar
+    equivalence-ratio: 0.84
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 299.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.3 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1140.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012901023890784982]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7770989761092151]
+          species-name: Ar
+    equivalence-ratio: 1.08
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 296.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 18.1 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1105.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012564102564102562]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7774358974358975]
+          species-name: Ar
+    equivalence-ratio: 1.05
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 288.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 18.2 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1112.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013904923599320884]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21000000000000002]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7760950764006791]
+          species-name: Ar
+    equivalence-ratio: 1.17
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 275.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.9 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1108.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012699009224461905]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.777300990775538]
+          species-name: Ar
+    equivalence-ratio: 1.062
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 190.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 34.105 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1107.015 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.011671341079503175]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7783286589204969]
+          species-name: Ar
+    equivalence-ratio: 0.971
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 187.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 33.854 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1092.187 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.011273227804542325]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7787267721954577]
+          species-name: Ar
+    equivalence-ratio: 0.936
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 250.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 34.585 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1080.157 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013169734151329245]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7768302658486708]
+          species-name: Ar
+    equivalence-ratio: 1.104
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 418.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 35.953 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1021.51 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.009363057324840765]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7806369426751593]
+          species-name: Ar
+    equivalence-ratio: 0.77
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 303.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.8 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1153.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013348467650397279]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7766515323496027]
+          species-name: Ar
+    equivalence-ratio: 1.12
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 452.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.6 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1072.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013904923599320884]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21000000000000002]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7760950764006791]
+          species-name: Ar
+    equivalence-ratio: 1.17
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 481.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.05 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1051.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.009013921113689096]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20999999999999996]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7809860788863109]
+          species-name: Ar
+    equivalence-ratio: 0.74
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 152.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.7 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1209.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012788844621513945]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21000000000000002]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7772111553784861]
+          species-name: Ar
+    equivalence-ratio: 1.07
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 344.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.4 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1117.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013348467650397279]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7766515323496027]
+          species-name: Ar
+    equivalence-ratio: 1.12
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 438.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.66 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1073.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.009246813441483197]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20999999999999996]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7807531865585168]
+          species-name: Ar
+    equivalence-ratio: 0.76
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 416.8 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.8 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1110.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.014788732394366197]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7752112676056337]
+          species-name: Ar
+    equivalence-ratio: 1.25
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 273.6 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.35 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1126.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01544637843907917]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7745536215609208]
+          species-name: Ar
+    equivalence-ratio: 1.31
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 314.4 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.6 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1112.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.009710982658959538]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7802890173410405]
+          species-name: Ar
+    equivalence-ratio: 0.8
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 611.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.8 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1051.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.010881410256410255]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7791185897435897]
+          species-name: Ar
+    equivalence-ratio: 0.97
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 367.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.1 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1116.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01381578947368421]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.21000000000000002]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7761842105263158]
+          species-name: Ar
+    equivalence-ratio: 1.25
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 458.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.2 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1061.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.009056603773584906]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20999999999999996]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.780943396226415]
+          species-name: Ar
+    equivalence-ratio: 0.8
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 160.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.8 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1194.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.011623203831825437]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7783767961681746]
+          species-name: Ar
+    equivalence-ratio: 1.04
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 506.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.1 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1053.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.00981203007518797]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.21]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7801879699248121]
+          species-name: Ar
+    equivalence-ratio: 0.87
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 444.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 16.9 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1085.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01225464190981432]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20999999999999996]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.7777453580901855]
+          species-name: Ar
+    equivalence-ratio: 1.1
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 416.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 17.2 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1082.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023244662632720633]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576755337367281]
+          species-name: Ar
+    equivalence-ratio: 1.018
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 532.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.96 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1285.646 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023781565296699535]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576218434703301]
+          species-name: Ar
+    equivalence-ratio: 1.043
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1309.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.398 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1204.883 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002384589080132224]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576154109198678]
+          species-name: Ar
+    equivalence-ratio: 1.046
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 783.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.262 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1243.523 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023803009575923397]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576196990424076]
+          species-name: Ar
+    equivalence-ratio: 1.044
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2498.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.551 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1155.005 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002444520314100375]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9575554796858996]
+          species-name: Ar
+    equivalence-ratio: 1.074
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1806.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.417 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1181.493 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0025212947189097107]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574787052810901]
+          species-name: Ar
+    equivalence-ratio: 1.11
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 483.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.224 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1289.898 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023373658981967584]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576626341018032]
+          species-name: Ar
+    equivalence-ratio: 1.024
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2711.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.35 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1154.013 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023094055165324653]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576905944834675]
+          species-name: Ar
+    equivalence-ratio: 1.011
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 770.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.662 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1239.521 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023137098155655796]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576862901844344]
+          species-name: Ar
+    equivalence-ratio: 1.013
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2039.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.874 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1173.362 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002523422860712055]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574765771392879]
+          species-name: Ar
+    equivalence-ratio: 1.111
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 365.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.117 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1317.156 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023244662632720633]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576755337367281]
+          species-name: Ar
+    equivalence-ratio: 1.018
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 232.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.801 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1374.106 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0025149088430737776]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574850911569263]
+          species-name: Ar
+    equivalence-ratio: 1.107
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 530.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.417 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1274.253 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0025765479700612386]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.039999999999999994]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574234520299387]
+          species-name: Ar
+    equivalence-ratio: 1.136
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 790.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.557 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1228.792 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002546816479400749]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.039999999999999994]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574531835205992]
+          species-name: Ar
+    equivalence-ratio: 1.122
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1050.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.827 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1197.514 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002572303504593399]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574276964954066]
+          species-name: Ar
+    equivalence-ratio: 1.134
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2200.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.984 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1154.238 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0010205527994330262]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9589794472005669]
+          species-name: Ar
+    equivalence-ratio: 0.432
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 653.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.538 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1231.347 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0011421842802472769]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.039999999999999994]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9588578157197527]
+          species-name: Ar
+    equivalence-ratio: 0.485
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1279.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.652 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1192.694 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.001146759286513216]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9588532407134868]
+          species-name: Ar
+    equivalence-ratio: 0.487
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1403.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.817 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1181.98 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0011787541909299452]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9588212458090701]
+          species-name: Ar
+    equivalence-ratio: 0.501
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2120.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.999 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1157.414 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.001144471918050159]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9588555280819498]
+          species-name: Ar
+    equivalence-ratio: 0.486
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 379.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.235 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1284.091 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.001137608196431726]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9588623918035682]
+          species-name: Ar
+    equivalence-ratio: 0.483
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 215.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.159 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1334.051 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004584674822923374]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9554153251770767]
+          species-name: Ar
+    equivalence-ratio: 2.136
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1715.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.593 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1186.016 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004458804523424878]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9555411954765752]
+          species-name: Ar
+    equivalence-ratio: 2.07
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 942.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.271 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1242.936 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004582774349342633]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9554172256506573]
+          species-name: Ar
+    equivalence-ratio: 2.135
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 403.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.873 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1323.682 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004535196131112306]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9554648038688878]
+          species-name: Ar
+    equivalence-ratio: 2.11
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1967.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.4 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1169.029 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004476021314387212]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.039999999999999994]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9555239786856128]
+          species-name: Ar
+    equivalence-ratio: 2.079
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 873.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.098 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1248.374 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004519944092033114]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9554800559079668]
+          species-name: Ar
+    equivalence-ratio: 2.102
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 400.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.613 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1329.898 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0028231848138342806]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9571768151861657]
+          species-name: Ar
+    equivalence-ratio: 1.253
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 822.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 53.802 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1110.42 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002726605297340035]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9572733947026599]
+          species-name: Ar
+    equivalence-ratio: 1.207
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 599.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 50.091 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1146.54 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0027392310732230565]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.039999999999999994]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9572607689267769]
+          species-name: Ar
+    equivalence-ratio: 1.213
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 253.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 49.284 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1235.292 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002401731799020167]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9575982682009798]
+          species-name: Ar
+    equivalence-ratio: 1.054
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1573.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 51.985 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1066.692 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0024038735403019078]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9575961264596982]
+          species-name: Ar
+    equivalence-ratio: 1.055
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2613.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 52.207 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1029.929 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002350256702795208]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576497432972046]
+          species-name: Ar
+    equivalence-ratio: 1.03
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 800.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.805 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1238.762 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.00238244514106583]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576175548589342]
+          species-name: Ar
+    equivalence-ratio: 1.045
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1673.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.98 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1190.011 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002259835315645014]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.039999999999999994]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.957740164684355]
+          species-name: Ar
+    equivalence-ratio: 0.988
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 523.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.39 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1284.676 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023995898137070585]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576004101862929]
+          species-name: Ar
+    equivalence-ratio: 1.053
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2711.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 13.16 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1145.343 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023223154649768796]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576776845350231]
+          species-name: Ar
+    equivalence-ratio: 1.017
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 267.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.31 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1355.74 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002177650429799427]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9578223495702005]
+          species-name: Ar
+    equivalence-ratio: 0.95
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 170.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.779 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1410.996 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002225274725274725]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9577747252747253]
+          species-name: Ar
+    equivalence-ratio: 0.972
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 363.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.02 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1318.373 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002129905898554051]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9578700941014459]
+          species-name: Ar
+    equivalence-ratio: 0.928
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 217.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.758 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1372.918 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002318013131601484]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576819868683986]
+          species-name: Ar
+    equivalence-ratio: 1.015
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 497.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.325 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1278.257 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002363138686131387]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576368613138686]
+          species-name: Ar
+    equivalence-ratio: 1.036
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 760.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.384 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1228.582 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0022555187006748256]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9577444812993252]
+          species-name: Ar
+    equivalence-ratio: 0.986
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2094.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.929 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1160.507 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002274935695913118]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9577250643040869]
+          species-name: Ar
+    equivalence-ratio: 0.995
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 702.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.648 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1263.647 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002604113547509774]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9573958864524902]
+          species-name: Ar
+    equivalence-ratio: 1.149
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1535.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.949 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1198.975 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002167634677892045]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.957832365322108]
+          species-name: Ar
+    equivalence-ratio: 1.017
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1754.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.841 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1185.164 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002230024470688371]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9577699755293116]
+          species-name: Ar
+    equivalence-ratio: 1.048
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2623.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 13.107 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1146.591 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0022058980091557543]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9577941019908444]
+          species-name: Ar
+    equivalence-ratio: 1.036
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 800.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.751 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1241.737 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0021777114851907102]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9578222885148094]
+          species-name: Ar
+    equivalence-ratio: 1.022
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 530.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.44 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1286.921 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002028024387635041]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9579719756123649]
+          species-name: Ar
+    equivalence-ratio: 0.948
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 320.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.064 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1341.939 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.001938458239519674]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9580615417604803]
+          species-name: Ar
+    equivalence-ratio: 0.904
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 237.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.82 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1385.971 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023561847197921633]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576438152802079]
+          species-name: Ar
+    equivalence-ratio: 1.111
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 2275.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.697 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1146.16 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0023022193904640546]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576977806095359]
+          species-name: Ar
+    equivalence-ratio: 1.084
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1240.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.449 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1181.384 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0024259102455546147]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9575740897544455]
+          species-name: Ar
+    equivalence-ratio: 1.146
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 815.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.257 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1218.744 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0020158356516156643]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9579841643483843]
+          species-name: Ar
+    equivalence-ratio: 0.942
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 507.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.171 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1277.834 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0022440840202073912]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.039999999999999994]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9577559159797926]
+          species-name: Ar
+    equivalence-ratio: 1.055
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 370.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.948 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1312.827 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0024457844070665397]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9575542155929334]
+          species-name: Ar
+    equivalence-ratio: 1.156
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 230.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.991 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1374.08 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002025316455696203]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9579746835443039]
+          species-name: Ar
+    equivalence-ratio: 0.88
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 163.5 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.277 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1483.2 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0018937644341801385]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9581062355658199]
+          species-name: Ar
+    equivalence-ratio: 0.82
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 431.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.343 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1420.9 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002354551676933607]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576454483230665]
+          species-name: Ar
+    equivalence-ratio: 1.032
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1184.7 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.345 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1338.1 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0025425652667423384]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574574347332575]
+          species-name: Ar
+    equivalence-ratio: 1.12
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1794.6 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.38 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1295.7 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0025212947189097107]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574787052810901]
+          species-name: Ar
+    equivalence-ratio: 1.11
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1020.4 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.333 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1356.1 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002025316455696203]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9579746835443039]
+          species-name: Ar
+    equivalence-ratio: 0.88
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 163.5 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.277 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1483.2 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0018937644341801385]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04000000000000001]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9581062355658199]
+          species-name: Ar
+    equivalence-ratio: 0.82
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 431.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.343 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1420.9 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.002354551676933607]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9576454483230665]
+          species-name: Ar
+    equivalence-ratio: 1.032
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1184.7 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.345 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1338.1 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0025425652667423384]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574574347332575]
+          species-name: Ar
+    equivalence-ratio: 1.12
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1794.6 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.38 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1295.7 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0025212947189097107]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.04]
+          species-name: O2
+        - InChI: 1S/Ar
+          amount: [0.9574787052810901]
+          species-name: Ar
+    equivalence-ratio: 1.11
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1020.4 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 1.333 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1356.1 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012499662094835993]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20745805418175714]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7800422837234068]
+          species-name: N2
+    equivalence-ratio: 0.99415
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 343.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.252 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1168.756 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.010947080505683845]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20778422678452024]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7812686927097959]
+          species-name: N2
+    equivalence-ratio: 0.8693
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 793.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.888 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1102.536 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.011797034636174219]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20760566499240038]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7805973003714254]
+          species-name: N2
+    equivalence-ratio: 0.9376
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1293.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.802 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1049.594 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.015123015574448876]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2069069295011662]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7779700549243849]
+          species-name: N2
+    equivalence-ratio: 1.206
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1593.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.353 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1034.222 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.010868606979585155]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20780071281941492]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7813306802009999]
+          species-name: N2
+    equivalence-ratio: 0.863
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 355.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.454 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1173.818 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012075471698113207]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20754716981132076]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.780377358490566]
+          species-name: N2
+    equivalence-ratio: 0.96
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 357.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.537 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1162.008 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012236992693018752]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20751323682919776]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7802497704777834]
+          species-name: N2
+    equivalence-ratio: 0.973
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1385.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.592 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1052.399 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012919766740398152]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20736979690327775]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7797104363563242]
+          species-name: N2
+    equivalence-ratio: 1.028
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 792.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.251 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1100.741 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01283292065207828]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2073880418798155]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7797790374681062]
+          species-name: N2
+    equivalence-ratio: 1.021
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 233.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.574 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1200.561 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0047393364928909965]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20908837468636748]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7861722888207416]
+          species-name: N2
+    equivalence-ratio: 0.374
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 125.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.335 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1256.201 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.00526875728253711]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2089771518313998]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7857540908860631]
+          species-name: N2
+    equivalence-ratio: 0.416
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 430.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.197 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1160.94 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0051427558077673345]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20900362272946063]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7858536214627719]
+          species-name: N2
+    equivalence-ratio: 0.406
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 510.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.902 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1147.997 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0051049491405191095]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2090115653066137]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7858834855528672]
+          species-name: N2
+    equivalence-ratio: 0.403
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1300.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.419 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1086.603 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.00513015390461714]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20900627018810566]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7858635759072772]
+          species-name: N2
+    equivalence-ratio: 0.405
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 800.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.276 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1120.257 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004789781798829165]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2090777769330191]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7861324412681517]
+          species-name: N2
+    equivalence-ratio: 0.378
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 255.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.567 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1199.971 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.010706638115631693]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20783473989167406]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7814586219926943]
+          species-name: N2
+    equivalence-ratio: 0.85
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1545.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.8 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1008.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012497799683154375]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20745844544471548]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7800437548721301]
+          species-name: N2
+    equivalence-ratio: 0.994
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 517.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.1 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1109.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012199723305244624]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20752106653251162]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7802792101622437]
+          species-name: N2
+    equivalence-ratio: 0.97
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 133.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 13.0 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1247.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013341373332328335]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.207281224089847]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7793774025778247]
+          species-name: N2
+    equivalence-ratio: 1.062
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 180.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 34.105 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1107.015 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01177714026876038]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2076098444813529]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7806130152498867]
+          species-name: N2
+    equivalence-ratio: 0.936
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 245.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 34.585 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1080.157 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013861684496007234]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20717191502184726]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7789664004821455]
+          species-name: N2
+    equivalence-ratio: 1.104
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 415.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 35.953 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1021.51 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0047393364928909965]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20908837468636748]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7861722888207416]
+          species-name: N2
+    equivalence-ratio: 0.374
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 125.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.335 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1256.201 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.00526875728253711]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2089771518313998]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7857540908860631]
+          species-name: N2
+    equivalence-ratio: 0.416
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 430.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.197 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1160.94 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0051427558077673345]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20900362272946063]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7858536214627719]
+          species-name: N2
+    equivalence-ratio: 0.406
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 510.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.902 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1147.997 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.0051049491405191095]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2090115653066137]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7858834855528672]
+          species-name: N2
+    equivalence-ratio: 0.403
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1300.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.419 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1086.603 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.00513015390461714]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.20900627018810566]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7858635759072772]
+          species-name: N2
+    equivalence-ratio: 0.405
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 800.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.276 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1120.257 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.004789781798829165]
+          species-name: JP-8
+        - InChI: 1S/O2/c1-2
+          amount: [0.2090777769330191]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7861324412681517]
+          species-name: N2
+    equivalence-ratio: 0.378
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 255.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.567 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1199.971 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.014799705418338199]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20697485180287017]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7782254427787917]
+          species-name: N2
+    equivalence-ratio: 1.17983
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 296.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.607 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1166.293 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.011007359646531463]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.2077715630994682]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7812210772540004]
+          species-name: N2
+    equivalence-ratio: 0.87414
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1645.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.503 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1023.675 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013911209321012457]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20716151064684613]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7789272800321414]
+          species-name: N2
+    equivalence-ratio: 1.108
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 718.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 9.857 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1109.396 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.014208253840747063]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.2070991063359775]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7786926398232753]
+          species-name: N2
+    equivalence-ratio: 1.132
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1440.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.052 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1030.752 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013366162504396767]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20727601628058895]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7793578212150143]
+          species-name: N2
+    equivalence-ratio: 1.064
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 115.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 9.511 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1252.884 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013390950430872047]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.2072708087330101]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7793382408361178]
+          species-name: N2
+    equivalence-ratio: 1.066
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 210.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.244 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1207.896 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01454221508425451]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20702894641087094]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7784288385048747]
+          species-name: N2
+    equivalence-ratio: 1.159
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 565.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.032 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1117.979 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.012199723305244624]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20752106653251162]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7802792101622437]
+          species-name: N2
+    equivalence-ratio: 0.97
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 930.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.65 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1074.372 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013068610203568738]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20733852726815788]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7795928625282735]
+          species-name: N2
+    equivalence-ratio: 1.04
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1220.8 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.2 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1011.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.014059753954305802]
+          species-name: Jet A
+        - InChI: 1S/O2/c1-2
+          amount: [0.20713030379111225]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7788099422545819]
+          species-name: N2
+    equivalence-ratio: 1.12
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 714.8 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.4 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1072.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013136186388661285]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20732433059061736]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7795394830207213]
+          species-name: N2
+    equivalence-ratio: 1.12465
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1381.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 12.627 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1023.658 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.010062934642595108]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20796997171374054]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7819670936436645]
+          species-name: N2
+    equivalence-ratio: 0.85886
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 640.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 11.985 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1117.713 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013898096189578065]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.2071642655063912]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7789376383040308]
+          species-name: N2
+    equivalence-ratio: 1.1908
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 134.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 10.934 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1228.556 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.014647913605299373]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20700674083922282]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7783453455554777]
+          species-name: N2
+    equivalence-ratio: 1.256
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 199.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 30.63 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1091.717 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.010690490966359496]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.2078381321499245]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.781471376883716]
+          species-name: N2
+    equivalence-ratio: 0.913
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 517.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 32.356 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1029.328 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.013888888888888888]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20716619981325865]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7789449112978525]
+          species-name: N2
+    equivalence-ratio: 1.19
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1452.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 15.3 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 999.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.014234045035585112]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.2070936880177342]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7786722669466806]
+          species-name: N2
+    equivalence-ratio: 1.22
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 498.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.6 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1087.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.01383133936387511]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20717829004960608]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7789903705865189]
+          species-name: N2
+    equivalence-ratio: 1.185
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 1285.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.9 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1015.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01
+  - composition:
+      kind: mole fraction
+      species:
+        - InChI: no InChI
+          amount: [0.015095879232966136]
+          species-name: JP-5
+        - InChI: 1S/O2/c1-2
+          amount: [0.20691263041324243]
+          species-name: O2
+        - InChI: 1S/N2
+          amount: [0.7779914903537913]
+          species-name: N2
+    equivalence-ratio: 1.295
+    ignition-type:
+      target: OH*
+      type: d/dt max
+    ignition-delay:
+      - 377.0 us
+      - uncertainty-type: relative
+        uncertainty: 0.15
+    pressure:
+      - 14.0 atm
+      - uncertainty-type: relative
+        uncertainty: 0.01
+    temperature:
+      - 1138.0 K
+      - uncertainty-type: relative
+        uncertainty: 0.01


### PR DESCRIPTION
Add a ChemKED file for shock tube ignition data from:

"Ignition delay time correlations for distillate fuels" 

https://www.sciencedirect.com/science/article/pii/S0016236116309048#s0065

The datapoints in this file were generated using this simple script:

```
from string import Template
import pandas as pd
import cantera as ct
import re

ct.suppress_thermo_warnings()

# create mapping of fuel names, models, and species names
nice_fuel_name = {
    'A1': 'JP-8',
    'A2': 'Jet A',
    'A3': 'JP-5'
}

model_name = {
    'A1': 'hychem_A1_highT.cti',
    'A2': 'hychem_A2_highT.cti',
    'A3': 'hychem_A3_highT.cti'
}

for name, model in model_name.items():
    model_name[name] = ct.Solution(model)

fuel_model_name = {
    'A1': 'POSF10264',
    'A2': 'POSF10325',
    'A3': 'POSF10289'
}


skeleton = Template("""
- composition:
    kind: mole fraction
    species:
      - InChI: no InChI
        amount: [${Xfuel}]
        species-name: ${fuel_name}
      - InChI: 1S/O2/c1-2
        amount: [${XO2}]
        species-name: O2
      - InChI: ${DChi}
        amount: [${XD}]
        species-name: ${Dilutant}
  equivalence-ratio: ${phi}
  ignition-type:
    target: OH*
    type: d/dt max
  ignition-delay:
    - ${tau} us
    - uncertainty-type: relative
      uncertainty: 0.15
  pressure:
    - ${pressure} atm
    - uncertainty-type: relative
      uncertainty: 0.01
  temperature:
    - ${temperature} K
    - uncertainty-type: relative
      uncertainty: 0.01
""".strip())


# get argon data -- skip empty rows
ar = pd.read_excel('davidson.xlsx', sheet_name='Argon Data New',
                   header=[2]).dropna(thresh=1)


for i, row in ar.iterrows():
    if 'Mixture' in row['Fuel']:
        # parse mixture
        mixture = row['Fuel']
        oxy_percent = float(re.compile(r'(\d+)%O2').search(
            mixture).groups()[0]) / 100.
        continue
    fuel = row['Fuel']
    # get gas
    try:
        gas = model_name[fuel]
    except KeyError:
        # not one of the model's were converting
        continue

    # get composition
    phi = float(row['Phi'])
    fuel_species = fuel_model_name[fuel]
    gas.set_equivalence_ratio(phi, fuel_species, 'O2')
    moles = gas.mole_fraction_dict()
    moles[fuel_species] *= oxy_percent
    moles['O2'] = oxy_percent
    moles['AR'] = 1 - sum(moles.values())
    gas.X = moles

    tau = float(row['tign (us)'])
    temp = float(row['T (K)'])
    pressure = float(row['P (atm)'])

    moles = gas.mole_fraction_dict()
    print(skeleton.substitute(
        Xfuel=moles[fuel_species],
        fuel_name=nice_fuel_name[fuel],
        XO2=moles["O2"],
        Dilutant="Ar",
        DChi="1S/Ar",
        XD=moles["AR"],
        tau=tau,
        temperature=temp,
        pressure=pressure,
        phi=phi))


# get air data -- skip empty rows
n2 = pd.read_excel('davidson.xlsx', sheet_name='N2 Data New',
                   header=[2]).dropna(thresh=1)


for i, row in n2.iterrows():
    fuel = row['Fuel']
    # get gas
    try:
        gas = model_name[fuel]
    except KeyError:
        # not one of the model's were converting
        continue

    # get composition
    phi = float(row['Phi'])
    fuel_species = fuel_model_name[fuel]
    gas.set_equivalence_ratio(phi, fuel_species, 'O2:1, N2:3.76')
    moles = gas.mole_fraction_dict()

    tau = float(row['tign (us)'])
    temp = float(row['T (K)'])
    pressure = float(row['P (atm)'])

    print(skeleton.substitute(
        Xfuel=moles[fuel_species],
        fuel_name=nice_fuel_name[fuel],
        XO2=moles["O2"],
        Dilutant="N2",
        DChi="1S/N2",
        XD=moles["N2"],
        tau=tau,
        temperature=temp,
        pressure=pressure,
        phi=phi))
```

Which can be run on the supplemental excel datasheet for that work (which I named 'davidson.xlsx').  
The mechanisms used were the hychem high-temperature models for the various jet-fuels -- specifically, I only really used them for convenience of getting the state via the equivalence ratio.  I can link the converted models on Slack if needed

A couple of things I'd love if someone looked over:

- When they say in the paper "fuel data measured in 4% O2/balance argon", this means that the composition was 4% O2, Fuel determined by phi (w/ pure O2), and Argon as the remaining `1 - (XO2 - XFuel)`, w/ `XO2=0.04`  ...? This is what I assumed in the script.
- Does this sentence in the paper:

>Non-reactive pressure profiles in these experiments (using N2 instead of O2 in the mixture) were adjusted using driver inserts to limit pressure (and hence also temperature) variations to less than 1% over the required test times 

imply that the relative uncertainty of the given pressure and temperature values are 1%?  This is what I assumed in the file, but I'm not sure it's correct.

- is it possible to have a common-properties that is generally correct, but needs an override for a specific value or keyword?  For example here I have a lot of uncertainties of the form:

```
    pressure:
      - 16.1 atm
      - uncertainty-type: relative
        uncertainty: 0.01
```

I don't know if I can apply a common uncertainty inside that map?