### PR TITLE
Toluene & n-heptane experimental RCM and ST datasets

### DIFF
--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-Ar-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-0.5-N2-Ar-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-Ar-10bar.yaml
@@ -1,11 +1,7 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
-
 reference:
   authors:
   - name: Zisis Malliotakis

--- a/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-50-50-phi-1-N2-Ar-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-Ar-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-0.5-N2-Ar-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-Ar-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-Ar-10bar.yaml
+++ b/n-heptane_toluene/rcm-malliotakis-2019-75-25-phi-1-N2-Ar-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: rapid compression machine
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm_sante-2011-25-75.yaml
+++ b/n-heptane_toluene/rcm_sante-2011-25-75.yaml
@@ -1,0 +1,98 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: R.Di Sante
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/j.combustﬂame.2011.05.020
+  journal: Combustion and Flame
+  pages: 56-63
+  volume: 159
+  year: 2012
+experiment-type: ignition delay
+apparatus:
+  facility: SAL RCM
+  institution: MIT
+  kind: rapid compression machine
+
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm_sante-2011-25-75.yaml
+++ b/n-heptane_toluene/rcm_sante-2011-25-75.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm_sante-2011-50-50.yaml
+++ b/n-heptane_toluene/rcm_sante-2011-50-50.yaml
@@ -1,0 +1,98 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: R.Di Sante
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/j.combustﬂame.2011.05.020
+  journal: Combustion and Flame
+  pages: 56-63
+  volume: 159
+  year: 2012
+experiment-type: ignition delay
+apparatus:
+  facility: SAL RCM
+  institution: MIT
+  kind: rapid compression machine
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm_sante-2011-50-50.yaml
+++ b/n-heptane_toluene/rcm_sante-2011-50-50.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/rcm_sante-2011-60-40.yaml
+++ b/n-heptane_toluene/rcm_sante-2011-60-40.yaml
@@ -1,0 +1,99 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: R.Di Sante
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/j.combustﬂame.2011.05.020
+  journal: Combustion and Flame
+  pages: 56-63
+  volume: 159
+  year: 2012
+experiment-type: ignition delay
+apparatus:
+  facility: SAL RCM
+  institution: MIT
+  kind: rapid compression machine
+                             
+
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/rcm_sante-2011-60-40.yaml
+++ b/n-heptane_toluene/rcm_sante-2011-60-40.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-0.5-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-1-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-50-50-phi-2-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
@@ -1,10 +1,7 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
-chemked-version: 0.4.1
+chemked-version: 0.4.11
 
 reference:
   authors:

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-0.5-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-1-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-75-25-phi-2-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-0.5-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-30bar.yaml
@@ -1,11 +1,7 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
-
 reference:
   authors:
   - name: Zisis Malliotakis

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-1-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-10bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-10bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-30bar.yaml
@@ -1,0 +1,102 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: Zisis Malliotakis
+  - name: Colin Banyon
+  - name: Kuiwen Zhang
+  - name: Scott Wagnon
+  detail: Experimental data captured from figures in literature
+  doi: https://doi.org/10.1016/j.combustﬂame.2018.10.024
+  journal: Combustion and Flame
+  pages: 241-248
+  volume: 199
+  year: 2019
+experiment-type: ignition delay
+apparatus:
+  facility: NUIG RCM & HPST
+  institution: National Technical University of Athens
+  kind: shcok tube
+                
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  pressure
+    type:  d/dt max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-30bar.yaml
+++ b/n-heptane_toluene/st-malliotakis-2019-90-10-phi-2-N2-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_M-Hartmann-2011-phi-0.5.yaml
+++ b/n-heptane_toluene/st_M-Hartmann-2011-phi-0.5.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_M-Hartmann-2011-phi-0.5.yaml
+++ b/n-heptane_toluene/st_M-Hartmann-2011-phi-0.5.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: M.Hartmann
+  - name: I.Gushterova
+  - name: M.Fikri
+  - name: C.Schulz
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/j.combustﬂame.2010.08.005
+  journal: Combustion and Flame
+  pages: 172-178
+  volume: 158
+  year: 2011
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_M-Hartmann-2011-phi-1.yaml
+++ b/n-heptane_toluene/st_M-Hartmann-2011-phi-1.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_M-Hartmann-2011-phi-1.yaml
+++ b/n-heptane_toluene/st_M-Hartmann-2011-phi-1.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: M.Hartmann
+  - name: I.Gushterova
+  - name: M.Fikri
+  - name: C.Schulz
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/j.combustﬂame.2010.08.005
+  journal: Combustion and Flame
+  pages: 172-178
+  volume: 158
+  year: 2011
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_herzler-2007-phi-0.3-10bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-0.3-10bar.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: J.Herzler
+  - name: M.Fikri
+  - name: K.Hitzbleck
+  - name: R.starke
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/J.COMBUSTFLAME.2006.12.015
+  journal: Combustion and Flame
+  pages: 25-31
+  volume: 149
+  year: 2007
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_herzler-2007-phi-0.3-10bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-0.3-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_herzler-2007-phi-0.3-30bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-0.3-30bar.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: J.Herzler
+  - name: M.Fikri
+  - name: K.Hitzbleck
+  - name: R.starke
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/J.COMBUSTFLAME.2006.12.015
+  journal: Combustion and Flame
+  pages: 25-31
+  volume: 149
+  year: 2007
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_herzler-2007-phi-0.3-30bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-0.3-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_herzler-2007-phi-0.3-50bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-0.3-50bar.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: J.Herzler
+  - name: M.Fikri
+  - name: K.Hitzbleck
+  - name: R.starke
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/J.COMBUSTFLAME.2006.12.015
+  journal: Combustion and Flame
+  pages: 25-31
+  volume: 149
+  year: 2007
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_herzler-2007-phi-0.3-50bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-0.3-50bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_herzler-2007-phi-1-10bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-1-10bar.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: J.Herzler
+  - name: M.Fikri
+  - name: K.Hitzbleck
+  - name: R.starke
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/J.COMBUSTFLAME.2006.12.015
+  journal: Combustion and Flame
+  pages: 25-31
+  volume: 149
+  year: 2007
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_herzler-2007-phi-1-10bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-1-10bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_herzler-2007-phi-1-30bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-1-30bar.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: J.Herzler
+  - name: M.Fikri
+  - name: K.Hitzbleck
+  - name: R.starke
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/J.COMBUSTFLAME.2006.12.015
+  journal: Combustion and Flame
+  pages: 25-31
+  volume: 149
+  year: 2007
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_herzler-2007-phi-1-30bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-1-30bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 

--- a/n-heptane_toluene/st_herzler-2007-phi-1-50bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-1-50bar.yaml
@@ -1,0 +1,101 @@
+file-authors:
+  - name: Bradley Carrano
+    ORCID: 0000-0003-3700-4155
+  - name: Kyle Niemeyer
+    ORCID: 0000-0003-4425-7097
+file-version: 0
+chemked-version: 0.4.1
+
+reference:
+  authors:
+  - name: J.Herzler
+  - name: M.Fikri
+  - name: K.Hitzbleck
+  - name: R.starke
+  detail: Experimental data captured from figures in literature
+  doi:10.1016/J.COMBUSTFLAME.2006.12.015
+  journal: Combustion and Flame
+  pages: 25-31
+  volume: 149
+  year: 2007
+experiment-type: ignition delay
+apparatus:
+  facility: IVG ST
+  institution: Universität Duisburg-Essen
+  kind: shock tube
+                             
+common-properties:
+  composition: &id001
+    kind: mole fraction
+    species:
+    - InChI: 1S/C7H16/c1-3-5-7-6-4-2/h3-7H2,1-2H3
+      amount:
+      - 0.010644203
+      species-name: Heptane
+    - InChI: 1S/C7H8/c1-7-5-3-2-4-6-7/h2-6H,1H3
+      amount:
+      - 0.009793735
+      species-name: Toluene
+    - InChI: 1S/O2/c1-2
+      amount:
+      - 0.205229847
+      species-name: O2
+    - InChI: 1S/N2/c1-2
+      amount:
+      - 0.774332215
+      species-name: N2
+  ignition-type: &id002
+    target:  CH*
+    type:   max
+datapoints:
+
+- composition: *id001
+  ignition-delay:
+  - 4.7210 ms
+  ignition-type: *id002
+  pressure:
+  - 11.85 atm
+  temperature:
+  - 791.939 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.1838 ms
+  ignition-type: *id002
+  pressure:
+  - 11.54 atm
+  temperature:
+  - 770.998 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 7.7536 ms
+  ignition-type: *id002
+  pressure:
+  - 11.22 atm
+  temperature:
+  - 749.615 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.1280 ms
+  ignition-type: *id002
+  pressure:
+  - 10.92 atm
+  temperature:
+  - 729.344 K
+  equivalence-ratio: 1.0
+
+- composition: *id001
+  ignition-delay:
+  - 10.9314 ms
+  ignition-type: *id002
+  pressure:
+  - 10.78 atm
+  temperature:
+  - 720.363 K
+  equivalence-ratio: 1.0
+

--- a/n-heptane_toluene/st_herzler-2007-phi-1-50bar.yaml
+++ b/n-heptane_toluene/st_herzler-2007-phi-1-50bar.yaml
@@ -1,8 +1,5 @@
 file-authors:
-  - name: Bradley Carrano
-    ORCID: 0000-0003-3700-4155
-  - name: Kyle Niemeyer
-    ORCID: 0000-0003-4425-7097
+  - name: Shenghui Qin
 file-version: 0
 chemked-version: 0.4.1
 


### PR DESCRIPTION
Description: Toluene & n-heptane experimental RCM and ST data points taken from figures on the references.
References:
[Auto-ignition of toluene doped n-heptane and iso-octane-air mixtures.pdf](https://github.com/pr-omethe-us/ChemKED-database/files/4504906/2.2Auto-ignition.of.toluene.doped.n-heptane.and.iso-octane-air.mixtures.pdf)
[Measurements of the auto-ignition of n-heptane-toluene mixtures using a rapid .pdf](https://github.com/pr-omethe-us/ChemKED-database/files/4504909/3Measurements.of.the.auto-ignition.of.n-heptane-toluene.mixtures.using.a.rapid.compression.machine.pdf)
[Shock-tube study of the autoignition of n-Heptane-Toluene-air.pdf](https://github.com/pr-omethe-us/ChemKED-database/files/4504910/5Shock-tube.study.of.the.autoignition.of.n-Heptane-Toluene-air.pdf)
[Testing the validity of a mechanism describing the oxidation of binary.pdf](https://github.com/pr-omethe-us/ChemKED-database/files/4504911/6Testing.the.validity.of.a.mechanism.describing.the.oxidation.of.binary.pdf)




